### PR TITLE
ISSUE-12: Fix file download from URL that provides an extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         "drupal/views_bulk_operations": "^3.9",
         "strawberryfield/strawberryfield":"dev-1.0.0-RC1",
         "strawberryfield/webform_strawberryfield":"dev-1.0.0-RC1",
-        "swaggest/json-schema":"^0.12.29",
-        "swaggest/json-diff":"^3.7.5",
+        "swaggest/json-schema": "^0.12.29",
+        "swaggest/json-diff": "^3.7.5",
         "phpoffice/phpspreadsheet": "^1.15.0",
         "maennchen/zipstream-php": "^1.2 || ^2.1",
         "drupal/google_api_client": "3.0.0-rc4",
-        "ramsey/uuid":"^4.1"
+        "ramsey/uuid": "^4.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/Entity/amiSetEntity.php
+++ b/src/Entity/amiSetEntity.php
@@ -387,7 +387,7 @@ class amiSetEntity extends ContentEntityBase implements amiSetEntityInterface {
       ->setDescription(t('A Zip file containing accompanying Files for the Source Data'))
       ->setSetting('file_extensions', 'zip')
       ->setSetting('upload_validators', $validatorszip)
-      ->setRequired(TRUE)
+      ->setRequired(FALSE)
       ->setDisplayOptions('view', [
         'label' => 'above',
         'type' => 'file',


### PR DESCRIPTION
See #12 

Allison, please test with mixed set of local files, remote files from DSpace and Islandora to have a larger variety of use cases. This worked out fine for me.

The remote fetch also can follow up at least 5 redirects, so http or https is as good as it gets.

## Side fix (and also a testing note for @alliomeria )

I removed the "required" ZIP upload from the AMI SET Edit Form. This allows users now to simply replace, from an existing SET the CSV (download, edit, remove the existing one, add the edited one) with an edited one. This way I could also add an Islandora datastream to an CSV that was fetching only from DSPACE without having to rebuild the SET. This is nice!

