### PR TITLE
ISSUE-18: Stricter validation and per bundle status/moderation option

### DIFF
--- a/ami.permissions.yml
+++ b/ami.permissions.yml
@@ -9,18 +9,28 @@ administer amiset entity:
   description: 'Allows users to administer AMI Set Entities created by the Archipelago Multi Importer'
   restrict access: TRUE
 view amiset entity:
-  title: 'View AMI Set Entities'
+  title: 'View any AMI Set Entities'
+view own amiset entity:
+  title: 'View own AMI Set Entities'
 add amiset entity:
   title: 'Add AMI Set Entities'
 edit amiset entity:
-  title: 'Edit AMI Set Entities'
+  title: 'Edit any AMI Set Entities'
   restrict access: TRUE
+edit own amiset entity:
+  title: 'Edit own AMI Set Entities'
 delete amiset entity:
-  title: 'Delete AMI Set Entities'
+  title: 'Delete any AMI Set Entities'
   restrict access: TRUE
+delete own amiset entity:
+  title: 'Delete own AMI Set Entities'
 process amiset entity:
-  title: 'Process AMI Set Entities'
+  title: 'Process any AMI Set Entities'
   restrict access: TRUE
+process own amiset entity:
+  title: 'Process own AMI Set Entities'
 deleteados amiset entity:
-  title: 'Delete ADOs generated through AMI Set Entities'
+  title: 'Delete ADOs generated through any AMI Set Entities'
   restrict access: TRUE
+deleteados own amiset entity:
+  title: 'Delete ADOs generated through own AMI Set Entities'

--- a/ami.routing.yml
+++ b/ami.routing.yml
@@ -77,7 +77,7 @@ entity.ami_set_entity.process_form:
     _entity_form: ami_set_entity.process
     _title: 'Process Ami Set'
   requirements:
-    _entity_access: 'ami_set_entity.edit'
+    _entity_access: 'ami_set_entity.process'
 
 entity.ami_set_entity.delete_process_form:
   path: '/amiset/{ami_set_entity}/deleteprocessed'
@@ -85,4 +85,4 @@ entity.ami_set_entity.delete_process_form:
     _entity_form: ami_set_entity.deleteprocessed
     _title: 'Process Ami Set'
   requirements:
-    _entity_access: 'ami_set_entity.edit'
+    _entity_access: 'ami_set_entity.deleteados'

--- a/src/AmiBatchQueue.php
+++ b/src/AmiBatchQueue.php
@@ -110,8 +110,8 @@ class AmiBatchQueue {
       \Drupal::messenger()->addMessage(
         \Drupal::translation()->formatPlural(
           count($results['processed']),
-          '%queue: One item successfully processed.',
-          '%queue: @count items successfully processed.',
+          '%queue: One item processed.',
+          '%queue: @count items processed.',
           ['%queue' => $results['queue_label']]
         )
       );

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -454,7 +454,7 @@ class AmiUtilityService {
         $extension = '';
       }
       $info = pathinfo($realpath);
-      if (($info['extension'] != $extension)) {
+      if (!isset($info['extension']) || $info['extension'] != $extension) {
         $newpath = $realpath . "." . $extension;
         $status = @rename($realpath, $newpath);
         if ($status === FALSE && !file_exists($newpath)) {

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -1261,6 +1261,10 @@ class AmiUtilityService {
           $newinfo[] = $info[$row_id];
           unset($info[$row_id]);
         }
+        else {
+          // Unset Invalid index if the row never existed
+          unset($invalid[$row_id]);
+        }
       }
     }
     $newinfo = array_merge($newinfo, $info);
@@ -1339,14 +1343,16 @@ class AmiUtilityService {
     // we may want to check if saved metadata headers == csv ones first.
     // $data->column_keys
     $config['data']['headers'] = $file_data_all['headers'];
+    $uuids = [];
 
     foreach ($file_data_all['data'] as $index => $keyedrow) {
       // This makes tracking of values more consistent and easier for the actual processing via
       // twig templates, webforms or direct
       $row = array_combine($config['data']['headers'], $keyedrow);
-      $possibleUUID = trim($row[$data->adomapping->uuid->uuid]);
+      $possibleUUID = $row[$data->adomapping->uuid->uuid] ?? NULL;
+      $possibleUUID = $possibleUUID ? trim($possibleUUID) : $possibleUUID;
       // Double check? User may be tricking us!
-      if (Uuid::isValid($possibleUUID)) {
+      if ($possibleUUID && Uuid::isValid($possibleUUID)) {
         $uuids[] = $possibleUUID;
         // Now be more strict for action = update
       }

--- a/src/Entity/Controller/amiSetEntityAccessControlHandler.php
+++ b/src/Entity/Controller/amiSetEntityAccessControlHandler.php
@@ -15,23 +15,77 @@ class amiSetEntityAccessControlHandler extends EntityAccessControlHandler {
    * $operation as defined in the routing.yml file.
    */
   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    if ($account->hasPermission('administer amiset entity')) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+    $is_owner = ($account->id() && $account->id() === $entity->getOwnerId());
+
     switch ($operation) {
       case 'view':
-        return AccessResult::allowedIfHasPermission($account, 'view amiset entity');
+          $access_result = AccessResult::allowedIf($account->hasPermission('view amiset entity'))
+            ->cachePerPermissions()
+            ->addCacheableDependency($entity);
+          if ($access_result->isForbidden()) {
+            $access_result = AccessResult::allowedIf($account->hasPermission('view own amiset entity'))
+              ->cachePerPermissions()
+              ->addCacheableDependency($entity);
+          }
+          return $access_result;
 
       case 'edit':
-        return AccessResult::allowedIfHasPermission($account, 'edit amiset entity');
+        if ($account->hasPermission('edit amiset entity')) {
+          return AccessResult::allowed()->cachePerPermissions();
+        }
+        if ($account->hasPermission('edit own amiset entity') && $is_owner) {
+          return AccessResult::allowed()->cachePerPermissions()->cachePerUser()->addCacheableDependency($entity);
+        }
+        else {
+          return AccessResult::neutral()
+            ->cachePerPermissions()
+            ->addCacheableDependency($entity);
+        }
 
       case 'delete':
-        return AccessResult::allowedIfHasPermission($account, 'delete amiset entity');
+        if ($account->hasPermission('delete amiset entity')) {
+          return AccessResult::allowed()->cachePerPermissions();
+        }
+        elseif ($account->hasPermission('delete own amiset entity') && $is_owner) {
+          return AccessResult::allowed()->cachePerPermissions()->cachePerUser()->addCacheableDependency($entity);
+        }
+        else {
+          return AccessResult::neutral()
+            ->cachePerPermissions()
+            ->addCacheableDependency($entity);
+        }
 
       case 'process':
-        return AccessResult::allowedIfHasPermission($account, 'process amiset entity');
+        if ($account->hasPermission('process amiset entity')) {
+          return AccessResult::allowed()->cachePerPermissions();
+        }
+        elseif ($account->hasPermission('process own amiset entity') && $is_owner) {
+          return AccessResult::allowed()->cachePerPermissions()->cachePerUser()->addCacheableDependency($entity);
+        }
+        else {
+          return AccessResult::neutral()
+            ->cachePerPermissions()
+            ->addCacheableDependency($entity);
+        }
 
       case 'deleteados':
-        return AccessResult::allowedIfHasPermission($account, 'deleteados amiset entity');
+        if ($account->hasPermission('deleteados amiset entity')) {
+          return AccessResult::allowed()->cachePerPermissions();
+        }
+        elseif ($account->hasPermission('deleteados own amiset entity') && $is_owner) {
+          return AccessResult::allowed()->cachePerPermissions()->cachePerUser()->addCacheableDependency($entity);
+        }
+        else {
+          return AccessResult::neutral()
+            ->cachePerPermissions()
+            ->addCacheableDependency($entity);
+        }
+      default:
+        return AccessResult::neutral()->cachePerPermissions();
     }
-    return AccessResult::allowed();
   }
 
   /**
@@ -41,7 +95,11 @@ class amiSetEntityAccessControlHandler extends EntityAccessControlHandler {
    * will be created during the 'add' process.
    */
   protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
-    return AccessResult::allowedIfHasPermission($account, 'add amiset entity');
+    $permissions = [
+      'administer amiset entity',
+      'add amiset entity',
+    ];
+    return AccessResult::allowedIfHasPermission($account, $permissions, 'OR');
   }
 
 }

--- a/src/Entity/Controller/amiSetEntityAccessControlHandler.php
+++ b/src/Entity/Controller/amiSetEntityAccessControlHandler.php
@@ -22,16 +22,17 @@ class amiSetEntityAccessControlHandler extends EntityAccessControlHandler {
 
     switch ($operation) {
       case 'view':
-          $access_result = AccessResult::allowedIf($account->hasPermission('view amiset entity'))
+        if ($account->hasPermission('view amiset entity')) {
+          return AccessResult::allowed()->cachePerPermissions();
+        }
+        if ($account->hasPermission('view own amiset entity') && $is_owner) {
+          return AccessResult::allowed()->cachePerPermissions()->cachePerUser()->addCacheableDependency($entity);
+        }
+        else {
+          return AccessResult::neutral()
             ->cachePerPermissions()
             ->addCacheableDependency($entity);
-          if ($access_result->isForbidden()) {
-            $access_result = AccessResult::allowedIf($account->hasPermission('view own amiset entity'))
-              ->cachePerPermissions()
-              ->addCacheableDependency($entity);
-          }
-          return $access_result;
-
+        }
       case 'edit':
         if ($account->hasPermission('edit amiset entity')) {
           return AccessResult::allowed()->cachePerPermissions();
@@ -49,7 +50,7 @@ class amiSetEntityAccessControlHandler extends EntityAccessControlHandler {
         if ($account->hasPermission('delete amiset entity')) {
           return AccessResult::allowed()->cachePerPermissions();
         }
-        elseif ($account->hasPermission('delete own amiset entity') && $is_owner) {
+        if ($account->hasPermission('delete own amiset entity') && $is_owner) {
           return AccessResult::allowed()->cachePerPermissions()->cachePerUser()->addCacheableDependency($entity);
         }
         else {
@@ -62,7 +63,7 @@ class amiSetEntityAccessControlHandler extends EntityAccessControlHandler {
         if ($account->hasPermission('process amiset entity')) {
           return AccessResult::allowed()->cachePerPermissions();
         }
-        elseif ($account->hasPermission('process own amiset entity') && $is_owner) {
+        if ($account->hasPermission('process own amiset entity') && $is_owner) {
           return AccessResult::allowed()->cachePerPermissions()->cachePerUser()->addCacheableDependency($entity);
         }
         else {
@@ -75,7 +76,7 @@ class amiSetEntityAccessControlHandler extends EntityAccessControlHandler {
         if ($account->hasPermission('deleteados amiset entity')) {
           return AccessResult::allowed()->cachePerPermissions();
         }
-        elseif ($account->hasPermission('deleteados own amiset entity') && $is_owner) {
+        if ($account->hasPermission('deleteados own amiset entity') && $is_owner) {
           return AccessResult::allowed()->cachePerPermissions()->cachePerUser()->addCacheableDependency($entity);
         }
         else {

--- a/src/Form/amiSetEntityDeleteProcessedForm.php
+++ b/src/Form/amiSetEntityDeleteProcessedForm.php
@@ -112,15 +112,10 @@ class amiSetEntityDeleteProcessedForm extends ContentEntityConfirmFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form['delete_enqueued'] = [
-      '#type' => 'checkbox',
-        '#title' => $this->t('Only delete enqueued but do not process Ingested ADOs'),
-        '#description' => $this->t(
-      'Check this to only deleted enqueue ADOs but not trigger an delete for already ingested ADOs.'
-    ),
-        '#required' => FALSE,
-        '#default_value' => $form_state->getValue('delete_enqueued')
-      ];
-
+      '#type' => 'fieldset',
+      '#title' => $this->t('Delete Ingested ADOs via this Set'),
+      '#description' => $this->t('Confirming will trigger a Batch Delete for already ingested ADOs.'),
+    ];
     return $form + parent::buildForm($form, $form_state);
   }
 

--- a/src/Form/amiSetEntityProcessForm.php
+++ b/src/Form/amiSetEntityProcessForm.php
@@ -102,11 +102,9 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
       $data = $item->provideDecoded(FALSE);
     }
     if ($file && $data !== new \stdClass()) {
-
       $info = $this->AmiUtilityService->preprocessAmiSet($file, $data);
       $SetURL = $this->entity->toUrl('canonical', ['absolute' => TRUE])
         ->toString();
-      $status =  $form_state->getValue('status', NULL);
       $notprocessnow = $form_state->getValue('not_process_now', NULL);
       $queue_name = 'ami_ingest_ado';
       if (!$notprocessnow) {


### PR DESCRIPTION
See #18 

This adds:
1.- Checks if `Content Moderation` is enabled and gets for chosen `Bundles` the valid workflows transitions for the current user.
2.- Shows Status Per Bundle. Even if a Bundle is not moderated we get a Publish/Unpublished option at least
3.- Removes the enqueue option for Delete Processed. Makes no sense to do that really (and can generate a Race condition)
4.- Adds a Naive validation for based settings i will move tomorrow into its own method (and make less naive). The idea here is that No Set gets ever processed without being sure data/config match.
5.- Adds 'moderation_status' during ingest in the Queue worker and falls back to Publish/Unpublish for unmoderated ones. Worst case always unpublished.

Still missing? If the ID passed as parent is numeric and not in scope? Carl saw an issue there but I can't find yet where this is happening, code is full of checks for that. May need to sleep...

Still, this is way better now.