### PR TITLE
ISSUE-22: Make sure we get the only ADO returned form the loadByProperty call.

### DIFF
--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -1118,11 +1118,12 @@ class AmiUtilityService {
         $ado['uuid'] = $possibleUUID;
         // Now be more strict for action = update/patch
         if ($data->pluginconfig->op !== 'create') {
-          $existing_object = $this->entityTypeManager->getStorage('node')
+          $existing_objects = $this->entityTypeManager->getStorage('node')
             ->loadByProperties(['uuid' => $ado['uuid']]);
           // Do access control here, will be done again during the atomic operation
           // In case access changes later of course
           // Processors do NOT delete. So we only check for Update.
+          $existing_object = $existing_objects && count($existing_objects) == 1 ? reset($existing_objects) : NULL;
           if (!$existing_object || !$existing_object->access('update')) {
             unset($ado);
             $invalid = $invalid + [$index => $index];
@@ -1165,9 +1166,7 @@ class AmiUtilityService {
               $invalid[$index] = $index;
             }
 
-            if ((!isset($invalid[$index]))
-              && (!isset($invalid[$parent_numeric]))
-            ) {
+            if ((!isset($invalid[$index])) && (!isset($invalid[$parent_numeric]))) {
               // Only traverse if we don't have this index or the parent one
               // in the invalid register.
               $parentchilds = [];
@@ -1360,14 +1359,14 @@ class AmiUtilityService {
       $possibleUUID = $possibleUUID ? trim($possibleUUID) : $possibleUUID;
       // Double check? User may be tricking us!
       if ($possibleUUID && Uuid::isValid($possibleUUID)) {
-        if ($op !== 'create') {
-          $existing_object = $this->entityTypeManager->getStorage('node')
+        if ($op !== 'create' && $op !== NULL) {
+          $existing_objects = $this->entityTypeManager->getStorage('node')
             ->loadByProperties(['uuid' => $possibleUUID]);
           // Do access control here, will be done again during the atomic operation
           // In case access changes later of course
           // This does NOT delete. So we only check for Update.
-          //@TODO field_descriptive_metadata  is passed from the Configuration
-          if ($existing_object && isset($existing_object[0]) && $existing_object[0]->access($op)) {
+          $existing_object = $existing_objects && count($existing_objects) == 1 ? reset($existing_objects) : NULL;
+          if ($existing_object && $existing_object->access($op)) {
             $uuids[] = $possibleUUID;
           }
         }

--- a/src/Form/AmiMultiStepIngest.php
+++ b/src/Form/AmiMultiStepIngest.php
@@ -459,9 +459,9 @@ class AmiMultiStepIngest extends AmiMultiStepIngestBaseForm {
         $data = $plugin_instance->getData($this->store->get('pluginconfig'), 0, -1);
         $amisetdata->column_keys = $data['headers'];
         $amisetdata->total_rows = $data['totalrows'];
-        // WE should probably add the UUIDs here right now.
+        // We should probably add the UUIDs here right now.
         $uuid_key = isset($amisetdata->adomapping['uuid']['uuid']) && !empty($amisetdata->adomapping['uuid']['uuid']) ? $amisetdata->adomapping['uuid']['uuid'] : 'uuid_node';
-        // WE want to reset this value now
+        // We want to reset this value now
         $amisetdata->adomapping['uuid']['uuid'] = $uuid_key;
         $fileid = $this->AmiUtilityService->csv_save($data, $uuid_key);
         if (isset($fileid)) {

--- a/src/Form/amiSetEntityDeleteProcessedForm.php
+++ b/src/Form/amiSetEntityDeleteProcessedForm.php
@@ -87,8 +87,8 @@ class amiSetEntityDeleteProcessedForm extends ContentEntityConfirmFormBase {
       $uuids = $this->AmiUtilityService->getProcessedAmiSetNodeUUids($file, $data, 'delete');
       if (empty($uuids)) {
         $form_state->setRebuild();
-        $this->messenger()->addError(
-          $this->t('So Sorry. There either no valid ADOs in the current CSV that can be deleted or that you have permission to. Please correct or try to manually delete your ADOs.')
+        $this->messenger()->addWarning(
+          $this->t('So Sorry. There either no ADOs in the current CSV that can be deleted or that you have permission to. Please correct or try to manually delete your ADOs. You may already have delete them too!')
         );
         return;
       }


### PR DESCRIPTION
# What?

A bug. I was calling `->access()` on a non existing entry because ` loadByProperty` used to load ADOs from UUID returns an array keyed by the NODE ID, and not sequential (I knew this, but I'm tired)
Only then I can call ->access()
Gist: I was doing it wrong, assuming the ADO would be found on [0] entry in the array.

Introduced by #19 !

This fixes #22 