### PR TITLE
ISSUE-21b(the return of the CSV) Islandora 7 migrations! ready to be used (almost?)

### DIFF
--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -325,6 +325,7 @@ class AmiUtilityService {
       }
     }
     else {
+      // This is remote!
       // Simulate what could be the final path of a remote download.
       // to avoid re downloading.
       $localfile = file_build_uri(
@@ -361,6 +362,7 @@ class AmiUtilityService {
         $finaluri = $localfile;
       }
     }
+    // This is the actual file creation independently of the source.
     if ($finaluri) {
       $file = $this->create_file_from_uri($finaluri);
       return $file;

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -645,16 +645,6 @@ class AmiUtilityService {
     }
     $file->setPermanent();
     $file->save();
-    // Tell the user where we have it.
-    $this->messenger()->addMessage(
-      $this->t(
-        'Your source data was saved and is available as CSV at. <a href="@url">@filename</a>.',
-        [
-          '@url' => file_create_url($file->getFileUri()),
-          '@filename' => $file->getFilename(),
-        ]
-      )
-    );
     return $file->id();
   }
 
@@ -957,9 +947,7 @@ class AmiUtilityService {
     $spl = NULL;
     clearstatcache(TRUE, $tempurl);
     $file->setFileUri($tempurl);
-
-    // This is how you close a \SplFileObject
-    // Notify the filesystem of the size change
+    $file->setFilename($filenametemp);
     $file->setSize($size);
     $file->save();
     return $file->id();

--- a/src/Form/AmiMultiStepIngest.php
+++ b/src/Form/AmiMultiStepIngest.php
@@ -527,10 +527,11 @@ class AmiMultiStepIngest extends AmiMultiStepIngestBaseForm {
         if (isset($fileid)) {
           $amisetdata->csv = $fileid;
           if ($plugin_instance->getPluginDefinition()['batch']) {
+            $data = $this->store->get('data');
+            $amisetdata->column_keys = $data['headers'];
             $batch = $plugin_instance->getBatch($form_state,
               $this->store->get('pluginconfig'), $amisetdata);
             $batch_data = $this->store->get('batch_finished');
-            $amisetdata->column_keys = $batch_data['headers'] ?? [];
             $amisetdata->total_rows = $batch_data['totalrows'] ?? 0;
             $id = $this->AmiUtilityService->createAmiSet($amisetdata);
             if ($id) {

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -346,7 +346,7 @@ class SolrImporter extends SpreadsheetImporter {
     }
 
     $config = $form_state->getValue($element['#parents']);
-    if (empty($config['host']) ||  empty($config['path']) || empty($config['collection'])) {
+    if (empty($config['host']) ||  empty($config['path']) || (empty($config['collection']) || $config['core'])) {
       $form_state->setError($element,
         t('Please fill Solr Server Config.'));
     }

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -136,6 +136,7 @@ class SolrImporter extends SpreadsheetImporter {
       '#suffix' => '</div>',
       '#tree' => TRUE,
       '#type' => 'fieldset',
+      '#title' => 'Solr Server Configuration',
       '#element_validate' => [[get_class($this), 'validateSolrConfig']],
       'islandora_collection' => [
         '#type' => 'textfield',
@@ -270,6 +271,7 @@ class SolrImporter extends SpreadsheetImporter {
       '#suffix' => '</div>',
       '#tree' => TRUE,
       '#type' => 'fieldset',
+      '#title' => 'Islandora Mappings',
       'collapse' => [
         '#type' => 'checkbox',
         '#title' => $this->t('Collapse Multi Children Objects'),
@@ -346,7 +348,8 @@ class SolrImporter extends SpreadsheetImporter {
     }
 
     $config = $form_state->getValue($element['#parents']);
-    if (empty($config['host']) ||  empty($config['path']) || (empty($config['collection']) || empty($config['core']))) {
+
+    if ((empty($config['host']) || empty($config['path']))) {
       $form_state->setError($element,
         t('Please fill Solr Server Config.'));
     }
@@ -363,10 +366,18 @@ class SolrImporter extends SpreadsheetImporter {
     ];
     if ($config['type'] == 'single') {
       $solr_config['endpoint']['amiremote']['core'] = $config['core'];
+      if (empty($config['core'])) {
+        $form_state->setError($element['core'],
+          t('Please Setup your Solr Core.'));
+      }
     }
     else {
       // Solr Cloud uses collection instead of core
       $solr_config['endpoint']['amiremote']['collection'] = $config['collection'];
+      if (empty($config['collection'])) {
+        $form_state->setError($element['collection'],
+          t('Please Setup your Solr Cloud Collection.'));
+      }
     }
 
     $adapter = new SolariumCurl(); // or any other adapter implementing AdapterInterface
@@ -419,7 +430,7 @@ class SolrImporter extends SpreadsheetImporter {
       $ping_sucessful = $result->getData();
     } catch (\Exception $e) {
       $form_state->setError($element,
-        $this->t('Ups. We could not contact your server. Check if your settings are correct and/or firewalls are open for this IP address.'));
+        $this->t('Ups. We could not contact your server. Check if your settings,ports,core,etc are correct and/or firewalls are open for this IP address.'));
       $form_state->setValue(['pluginconfig','ready'], FALSE);
       return $tabdata;
     }

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -686,6 +686,9 @@ class SolrImporter extends SpreadsheetImporter {
         // also note that the same can be done using the placeholder syntax, see example 6.3
         $helper = $query->getHelper();
         $query->setQuery('RELS_EXT_isMemberOfCollection_uri_s:' . $helper->escapePhrase($input));
+        // PLEASE REMOVE Collection Objects that ARE ALSO part of a compound. WE DO NOT WANT THOSE
+        $query->createFilterQuery('notconstituent')->setQuery('-RELS_EXT_isConstituentOf_uri_ms:[ * TO * ]');
+
         $query->setStart($offset)->setRows($per_page);
         $query->setFields([
           'PID',

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -346,7 +346,7 @@ class SolrImporter extends SpreadsheetImporter {
     }
 
     $config = $form_state->getValue($element['#parents']);
-    if (empty($config['host']) ||  empty($config['path']) || (empty($config['collection']) || $config['core'])) {
+    if (empty($config['host']) ||  empty($config['path']) || (empty($config['collection']) || empty($config['core']))) {
       $form_state->setError($element,
         t('Please fill Solr Server Config.'));
     }

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -10,7 +10,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use GuzzleHttp\ClientInterface;
-use Hoa\Math\Sampler\Random;
 use Solarium\Core\Query\AbstractQuery as SolariumAbstractQuery;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\ami\AmiUtilityService;
@@ -238,9 +237,17 @@ class SolrImporter extends SpreadsheetImporter {
     }
 
     $default_parent = $form_state->getValue(array_merge($parents,
-      ['solarium_mapping', 'parent_ado'], NULL));
+      ['solarium_mapping', 'parent_ado']), NULL);
     if ($default_parent) {
-      $default_parent = $this->entityTypeManager->getStorage('node')->load($default_parent);
+      try {
+        $default_parent = $this->entityTypeManager->getStorage('node')
+          ->load($default_parent);
+      }
+      catch (\Exception $e) {
+        $this->messenger()->addError('Could not load Parent ADO with message @e'. [
+          '@e' => $e->getMessage(),
+          ]);
+      }
     }
 
     $form['solarium_mapping'] = [
@@ -339,7 +346,7 @@ class SolrImporter extends SpreadsheetImporter {
         ],
       ],
     ];
-    if ($config['solarium_config']['type'] == 'single') {
+     if ($config['solarium_config']['type'] == 'single') {
       $solr_config['endpoint']['amiremote']['core'] = $config['solarium_config']['core'];
     }
     else {
@@ -409,6 +416,11 @@ class SolrImporter extends SpreadsheetImporter {
         $allheaders = $resultset->getResponse()->getBody();
         $allheaders_array = str_getcsv($allheaders);
         $allheaders_array = array_map([$this, 'multipleToSingleFieldName'], $allheaders_array);
+        // Remove this non sense of mods_*_authority_marcrelator
+        array_filter($allheaders_array, function ($value) {
+          return $this->endsWith($value, 'authority_marcrelator');
+        });
+
         // Reuse the query now
         $query->setResponseWriter(SolariumAbstractQuery::WT_JSON);
         $query->setStart($config['solarium_config']['start'] ?? 0)->setRows($rows);
@@ -418,7 +430,7 @@ class SolrImporter extends SpreadsheetImporter {
         $cmodel = [];
         $collapse_children =  $config['solarium_mapping']['collapse'] ?? FALSE;
         foreach ($facet as $value => $count) {
-          if ($count || $collapse_children) {
+          if ($count || !$collapse_children) {
             $cmodel[$value] = $value;
           }
         }
@@ -462,13 +474,16 @@ class SolrImporter extends SpreadsheetImporter {
           $document = $resultset_iterator->current();
           foreach ($document as $field => $value) {
             $fieldname = $field;
+            $fieldname = $this->multipleToSingleFieldName($field);
             // Exclude this non-sense fields
             if (strpos($field, '_roleTerm_', 0) !== FALSE) {
               continue;
             }
-            // this converts multi valued fields to a |@|  string
-            $fieldname = $this->multipleToSingleFieldName($field);
+            if ($this->endsWith($fieldname, 'authority_marcrelator')) {
+              continue;
+            }
             $headers[$fieldname] = $fieldname;
+            // this converts multi valued fields to a |@|  string
             if (is_array($value)) {
               $original_value = $sp_data[$resultset_iterator->key()][$fieldname] ?? NULL;
               $value = $this->concatValues($value, $original_value);
@@ -549,6 +564,11 @@ class SolrImporter extends SpreadsheetImporter {
         ],
       ],
     ];
+    $parent_ado =  $config['parent_ado_uuid'] ?? NULL;
+    // Passed by batch operation
+    $headers = $config['headers'] ?? [];
+    $headers = array_combine($headers, $headers);
+    $headersWithData = $config['headerswithdata'] ?? [];
 
     if ($config['solarium_config']['type'] == 'single') {
       $solr_config['endpoint']['amiremote']['core'] = $config['solarium_config']['core'];
@@ -560,14 +580,16 @@ class SolrImporter extends SpreadsheetImporter {
 
     $adapter = new SolariumCurl(); // or any other adapter implementing AdapterInterface
     $eventDispatcher = new EventDispatcher();
-    $tabdata = ['headers' => [], 'data' => [], 'totalrows' => 0, 'totalfound' => 0];
+    // This adds 'headerswithdata' so we can clean our mess up once finished
+    $tabdata = ['headers' => [], 'data' => [], 'totalrows' => 0, 'totalfound' => 0, 'headerswithdata' => $headersWithData];
     $client = new SolariumClient($adapter, $eventDispatcher, $solr_config);
     $ping = $client->createPing();
     // execute the ping query
     try {
       $result = $client->ping($ping);
       $ping_sucessful = $result->getStatus() + 1;
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       return $tabdata;
     }
 
@@ -623,12 +645,14 @@ class SolrImporter extends SpreadsheetImporter {
       }
       $table = [];
       foreach (static::FILE_COLUMNS as $column) {
-        $headers[$column] = $column;
+        $headers[$column] = $headersWithData[$column] = $column;
       }
-      $headers['type'] = 'type';
-      $headers['ismemberof'] = 'ismemberof';
-      $headers['ispartof'] = 'ispartof';
-      $maxRow = 0;
+      // Ensure the basic fields for this data
+      $headers['type'] =  $headersWithData['type'] = 'type';
+      $headers['ismemberof'] = $headersWithData['ismemberof'] = 'ismemberof';
+      $headers['ispartof'] = $headersWithData['ispartof'] = 'ispartof';
+      $headersWithData['node_uuid'] = 'node_uuid';
+
       $highestRow = 0;
       $pids_to_fetch = [];
       $previous_index = $config['prev_index'] ?? 0;
@@ -638,7 +662,6 @@ class SolrImporter extends SpreadsheetImporter {
           $highestRow = $resultset_iterator->key() + 1;
           $document = $resultset_iterator->current();
           foreach ($document as $field => $value) {
-            $fieldname = $field;
             // Exclude this non-sense fields
             if (strpos($field, '_roleTerm_', 0) !== FALSE) {
               continue;
@@ -654,6 +677,9 @@ class SolrImporter extends SpreadsheetImporter {
           // Let's add generic all columns needed for files.
           foreach (static::FILE_COLUMNS as $column) {
             $sp_data[$resultset_iterator->key()][$column] = '';
+          }
+          if ($parent_ado) {
+            $sp_data[$resultset_iterator->key()]['ismemberof'] = $parent_ado;
           }
           $sp_data[$resultset_iterator->key()]['type'] = $config['solarium_mapping']['cmodel_mapping'][$sp_data[$resultset_iterator->key()]['RELS_EXT_hasModel_uri']] ?? 'Thing';
 
@@ -681,6 +707,10 @@ class SolrImporter extends SpreadsheetImporter {
           $newrow = [];
           $realrowindex = $rowindex + $childrenoffset + $previous_index;
           foreach ($headers as $field) {
+            // We keep track of empty headers here.
+            if (!empty($sp_data[$rowindex][$field])) {
+              $headersWithData[$field] = $field;
+            }
             $newrow[$i] = $sp_data[$rowindex][$field] ?? '';
             $i++;
           }
@@ -694,6 +724,9 @@ class SolrImporter extends SpreadsheetImporter {
                 $newrow = [];
                 if (!$collapse_children) {
                   foreach ($headers as $field) {
+                    if (!empty($children_data[$childrenindex][$field])) {
+                      $headersWithData[$field] = $field;
+                    }
                     if ($field == 'ispartof') {
                       // Arrays. Headers is 0, first row is 1, but in CSV
                       // Headers is 1. You got this.
@@ -729,11 +762,15 @@ class SolrImporter extends SpreadsheetImporter {
         }
       }
 
+      // Clean empty headers
+
+
       $tabdata = [
         'headers' => array_keys($headers),
         'data' => $table,
         'totalrows' => $highestRow,
         'totalfound' => count($table),
+        'headerswithdata' => $headersWithData,
       ];
     }
     else {
@@ -776,7 +813,6 @@ class SolrImporter extends SpreadsheetImporter {
       'fedora_datastreams_ms'
     ]);
 
-    error_log($client->createRequest($query)->getUri());
     $resultset = $client->select($query);
     // display the total number of documents found by solr
     error_log('NumFound: ' . $resultset->getNumFound());
@@ -797,9 +833,12 @@ class SolrImporter extends SpreadsheetImporter {
         $highestRow = $resultset_iterator->key() + 1;
         $document = $resultset_iterator->current();
         foreach ($document as $field => $value) {
-          $fieldname = $field;
+          $fieldname = $this->multipleToSingleFieldName($field);
           // Exclude this non-sense fields
           if (strpos($field, '_roleTerm_', 0) !== FALSE) {
+            continue;
+          }
+          if ($this->endsWith($fieldname, 'authority_marcrelator')) {
             continue;
           }
           // this converts multi valued fields to a comma-separated string
@@ -829,7 +868,8 @@ class SolrImporter extends SpreadsheetImporter {
         // Get me the datastream
         $datastream = $this->buildDatastreamURL($config, $document);
         if (count($datastream)) {
-          $sp_data[$resultset_iterator->key()][array_key_first($datastream)] = reset($datastream);
+          $first_datastream = reset($datastream);
+          $sp_data[$resultset_iterator->key()][key($datastream)] = $first_datastream;
         }
       } catch (\Exception $exception) {
         // @TODO log the error here.
@@ -888,6 +928,21 @@ class SolrImporter extends SpreadsheetImporter {
     return $field;
   }
 
+
+  /**
+   * Checks if string ends in another string. PHP 7.
+   *
+   * @param $haystack
+   * @param $needle
+   *
+   * @return bool
+   */
+  protected function endsWith($haystack, $needle) {
+    $length = strlen($needle);
+    return $length > 0 ? substr($haystack, -$length) === $needle : true;
+  }
+
+
   /**
    * Implodes array and concatenates to existing string using common delimiter.
    *
@@ -915,9 +970,13 @@ class SolrImporter extends SpreadsheetImporter {
       'finished' => '\Drupal\ami\Plugin\ImporterAdapter\SolrImporter::finishfetchFromSolr',
       'progress_message' => t('Processing Set @current of @total.'),
     ];
-
-    $file =  $this->entityTypeManager->getStorage('file')->load($amisetdata->csv);
-
+    $parent_ado_uuid = NULL;
+    $file = $this->entityTypeManager->getStorage('file')->load($amisetdata->csv);
+    if (!empty($config['solarium_mapping']['parent_ado']) && is_scalar($config['solarium_mapping']['parent_ado'])) {
+      $parent_ado = $this->entityTypeManager->getStorage('node')->load($config['solarium_mapping']['parent_ado']);
+      $parent_ado_uuid = $parent_ado->uuid();
+    }
+    $config['parent_ado_uuid'] = $parent_ado_uuid;
     $batch['operations'][] = [
       '\Drupal\ami\Plugin\ImporterAdapter\SolrImporter::fetchBatch',
       [$config, $this, $file, $amisetdata],
@@ -928,7 +987,7 @@ class SolrImporter extends SpreadsheetImporter {
   /**
    * {@inheritdoc}
    */
-  public static function fetchBatch(array $config, ImporterPluginAdapterInterface $plugin_instace, File $file, \stdClass $amisetdata, array &$context):void {
+  public static function fetchBatch(array $config, ImporterPluginAdapterInterface $plugin_instance, File $file, \stdClass $amisetdata, array &$context):void {
 
     $rows = $config['solarium_config']['rows'] ?? 500;
     $offset = $config['solarium_config']['start'] ?? 0;
@@ -957,7 +1016,11 @@ class SolrImporter extends SpreadsheetImporter {
       // And we pass that data into the ::getData to offset the next set of
       // Parents/Children.
       $config['prev_index'] = $context['sandbox']['prev_index'];
-      $data = $plugin_instace->getData($config, $context['sandbox']['progress'] + $offset,
+      // Pass the headers into the config so we have a unified/normalized version
+      // And not the mess each doc returns
+      $config['headers'] = $amisetdata->column_keys ?? [];
+      $config['headerswithdata'] = $context['results']['processed']['headerswithdata'] ?? [];
+      $data = $plugin_instance->getData($config, $context['sandbox']['progress'] + $offset,
         $increment);
       if ($data['totalrows'] == 0) {
         $context['finished'] = 1;
@@ -968,9 +1031,10 @@ class SolrImporter extends SpreadsheetImporter {
         \Drupal::service('ami.utility')->csv_append($data, $file, $amisetdata->adomapping['uuid']['uuid'], $append_headers);
         $context['sandbox']['progress'] = $context['sandbox']['progress'] + $data['totalrows'];
         // Update context
-
-        $context['results']['processed']['headers'][] = $data['headers'];
-        $context['results']['processed']['total_rows'] = $context['sandbox']['prev_index'] + $data['totalfound'];
+        $context['results']['processed']['fileuuid'] = $file->uuid();
+        $context['results']['processed']['headers'] = $data['headers'];
+        $context['results']['processed']['total_rows'] = $data['totalrows'] ?? 0;
+        $context['results']['processed']['headerswithdata'] = $data['headerswithdata'] ?? [];
         $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['max'];
       }
     } catch (\Exception $e) {
@@ -985,16 +1049,14 @@ class SolrImporter extends SpreadsheetImporter {
   public static function finishfetchFromSolr($success, $results, $operations) {
     error_log('finished');
     $allheaders = $results['processed']['headers'] ?? [];
-    $cleanheaders = [];
-    foreach($allheaders as $headerarray) {
-      $cleanheaders = array_unique(array_merge($cleanheaders, $headerarray));
-    }
-    error_log(var_export($cleanheaders, true));
 
-    $data['headers'] = array_values($cleanheaders);
+    $data['headers'] = array_values($allheaders);
     $data['total_rows'] = $results['processed']['total_rows'] ?? 0;
-    error_log(var_export($data['total_rows'], true));
-
+    // Clean the CSV removing empty headers!
+    $file = \Drupal::service('entity.repository')->loadEntityByUuid('file', $results['processed']['fileuuid']);
+    if ($file) {
+      \Drupal::service('ami.utility')->csv_clean($file, $results['processed']['headerswithdata']);
+    }
     \Drupal::service('tempstore.private')->get('ami_multistep_data')->set('batch_finished', $data);
   }
 

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -793,7 +793,7 @@ class SolrImporter extends SpreadsheetImporter {
 
           $table[$realrowindex] = $newrow;
           if (isset($pids_to_fetch[$rowindex])) {
-            $children_data = $this->getDataChildren($config, $client, 'info:fedora/'.$pids_to_fetch[$rowindex]);
+            $children_data = $this->getDataChildren($config, $client, $pids_to_fetch[$rowindex]);
             if (count($children_data)) {
               foreach ($children_data as $childrenindex => $childrenrow) {
                 $j = 0;
@@ -871,7 +871,9 @@ class SolrImporter extends SpreadsheetImporter {
     $sp_data = [];
     $query = $client->createSelect();
     $helper = $query->getHelper();
-    $escaped = $helper->escapePhrase($input);
+    $escaped = $helper->escapePhrase('info:fedora/' . $input);
+    $escaped_pid = str_replace(':', '_', $input);
+    $query->addSort("RELS_EXT_isSequenceNumberOf{$escaped_pid}_literal_intDerivedFromString_l", 'asc');
     $query->createFilterQuery('constituent')->setQuery('RELS_EXT_isConstituentOf_uri_ms:'.$escaped .' OR RELS_EXT_isPageOf_uri_ms:'.$escaped .' OR RELS_EXT_isMemberOf_uri_ms:'.$escaped );
     $query->setQuery('*:*');
     $query->setStart(0)->setRows(3000);

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -218,7 +218,7 @@ class SolrImporter extends SpreadsheetImporter {
         '#title' => $this->t('Starting Row'),
         '#description' => $this->t('Initial Row to fetch. This is an offset. Defaults to 0'),
         '#default_value' => $form_state->getValue(array_merge($parents,
-          ['solarium_config', 'start'])),
+          ['solarium_config', 'start']), 0),
       ],
       'rows' => [
         '#type' => 'number',
@@ -340,7 +340,18 @@ class SolrImporter extends SpreadsheetImporter {
   }
 
   public static function validateSolrConfig($element, FormStateInterface $form_state) {
+
+    if (isset($form_state->getTriggeringElement()['#name']) && $form_state->getTriggeringElement()['#name'] == 'prev') {
+      return;
+    }
+
     $config = $form_state->getValue($element['#parents']);
+    if (empty($config['host']) ||  empty($config['path']) || empty($config['collection'])) {
+      $form_state->setError($element,
+        t('Please fill Solr Server Config.'));
+    }
+    $config['port'] = !empty($config['port']) ? (int)$config['port'] : NULL;
+
     $solr_config = [
       'endpoint' => [
         'amiremote' => [
@@ -1127,7 +1138,7 @@ class SolrImporter extends SpreadsheetImporter {
 
   public function provideKeys(array $config, array $data): array {
     if (count($data) > 0) {
-      $columns = array_merge(['type','node_uuid','ismemberof','ispartof','fgs_label'], static::FILE_COLUMNS);
+      $columns = array_merge(['type','node_uuid','ismemberof','ispartof','fgs_label','mods_titleInfo_title'], static::FILE_COLUMNS);
       return $columns;
     }
     return [];

--- a/src/Plugin/ImporterAdapter/SpreadsheetImporter.php
+++ b/src/Plugin/ImporterAdapter/SpreadsheetImporter.php
@@ -30,12 +30,6 @@ class SpreadsheetImporter extends ImporterAdapterBase {
   protected $streamWrapperManager;
 
   /**
-   * @var \Drupal\ami\AmiUtilityService
-   */
-  protected $AmiUtilityService;
-
-
-  /**
    * SpreadsheetImporter constructor.
    *
    * @param array $configuration
@@ -48,9 +42,8 @@ class SpreadsheetImporter extends ImporterAdapterBase {
    * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entityTypeManager,  StreamWrapperManagerInterface $streamWrapperManager, AmiUtilityService $ami_utility) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entityTypeManager);
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entityTypeManager, $ami_utility);
     $this->streamWrapperManager = $streamWrapperManager;
-    $this->AmiUtilityService = $ami_utility;
   }
 
   /**

--- a/src/Plugin/ImporterAdapterBase.php
+++ b/src/Plugin/ImporterAdapterBase.php
@@ -119,7 +119,7 @@ abstract class ImporterAdapterBase extends PluginBase implements ImporterPluginA
   /**
    * {@inheritdoc}
    */
-  public static function fetchBatch(array $config, ImporterPluginAdapterInterface $plugin_instace, File $file, \stdClass $amisetdata, array &$context):void {
+  public static function fetchBatch(array $config, ImporterPluginAdapterInterface $plugin_instance, File $file, \stdClass $amisetdata, array &$context):void {
   }
 
 

--- a/src/Plugin/ImporterAdapterInterface.php
+++ b/src/Plugin/ImporterAdapterInterface.php
@@ -99,7 +99,7 @@ interface ImporterAdapterInterface extends PluginInspectionInterface {
    *  Only applies to plugins with batch = true annotations
    *
    * @param array $config
-   * @param \Drupal\ami\Plugin\ImporterAdapterInterface $plugin_instace
+   * @param \Drupal\ami\Plugin\ImporterAdapterInterface $plugin_instance
    * @param \Drupal\file\Entity\File $file
    *    A File ID of an existing CSV to append data to.
    * @param \stdClass $amisetdata
@@ -107,6 +107,6 @@ interface ImporterAdapterInterface extends PluginInspectionInterface {
    *
    * @return mixed
    */
-  public static function fetchBatch(array $config, ImporterPluginAdapterInterface $plugin_instace, File $file, \stdClass $amisetdata, array &$context):void;
+  public static function fetchBatch(array $config, ImporterPluginAdapterInterface $plugin_instance, File $file, \stdClass $amisetdata, array &$context):void;
 
 }

--- a/src/Plugin/ImporterAdapterInterface.php
+++ b/src/Plugin/ImporterAdapterInterface.php
@@ -109,4 +109,25 @@ interface ImporterAdapterInterface extends PluginInspectionInterface {
    */
   public static function fetchBatch(array $config, ImporterPluginAdapterInterface $plugin_instance, File $file, \stdClass $amisetdata, array &$context):void;
 
+
+  /**
+   * Allows Plugin to provide its own version of the Data Keys (columns) it wants to expose to the UI
+   *
+   * @param array $config
+   * @param array $data
+   *
+   * @return array
+   */
+  public function provideKeys(array $config, array $data):array;
+
+  /**
+   *  Allows Plugin to provide its own version of the ADO types it wants to expose to the UI
+   *
+   * @param array $config
+   * @param array $data
+   *
+   * @return array
+   */
+  public function provideTypes(array $config, array $data):array;
+
 }


### PR DESCRIPTION
## What? Islandora 7 importer ready for testing!
See #21 This is the second part, now full fledged with CSV header normalizer, cleaning out empty columns, parents, mapping for Compounds even if we DO not know what we will get and AMI Set creation at the end of the BATCH. Also some memory optimizations (this is heavy!)

## Some stuff:
- Better CSV header normalizing. WE get all fields first. The fetch. We keep track of the ones that actually have values per row. Once ready with the CSV we go back, make a diff on the headers and only keep the ones that are REALLY not empty and write a new clean CSV out.
- trying to get rid of authority_marcrelator fields (may need more work?)
- AMI set gets created and redirected to the Set.
Tested with 7000 Objects, took 25 seconds?
- Parent Object gets set into ismemberof
`@TODO`:
- Cleanups, probably more checks? Lots of checks here
- Remove temp files/stuff around
- Clear form states/steps
- Change the message at the end (since we are redirecting we have a different message

@alliomeria this solves like 95% of the things we discussed today. the CSV is waaaayy less scary 🥧 and more 🌴 

There are some cosmetics to do, but already looking better. I show at the end two CSVs. ON the message itself the original (like 700 columns!!) but in the Set itself, the attached one is clean, normalized, beautiful.