### PR TITLE
ISSUE-59: Offset ::csv_count(File $file) by 1 and get around PHP8 bug

### DIFF
--- a/src/Form/amiSetEntityReconcileForm.php
+++ b/src/Form/amiSetEntityReconcileForm.php
@@ -485,6 +485,19 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
       '\Drupal\ami\AmiLoDBatchQueue::takeOne',
       [$queue_name, $this->entity->id()],
     ];
+    /* Because batch set will run on Ajax
+    and we want that afterwards the form is fresh
+    we remove $userInput to force a rebuild */
+    $userInput = $form_state->getUserInput();
+    $keys = $form_state->getCleanValueKeys();
+
+    $newInputArray = [];
+    foreach ($keys as $key) {
+      if ($key == "op")  continue;
+      $newInputArray[$key] = $userInput[$key];
+    }
+    $form_state->setUserInput($newInputArray);
+
     batch_set($batch);
   }
 

--- a/src/Form/amiSetEntityReconcileForm.php
+++ b/src/Form/amiSetEntityReconcileForm.php
@@ -89,6 +89,13 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
+  public function getDescription() {
+    return $this->t('This action will overwrite any manually corrected LoD on your Processed CSV. Please make sure you have a backup if unsure.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function buildForm(array $form, FormStateInterface $form_state) {
     // Read Config first to get the Selected Bundles based on the Config
     // type selected. Based on that we can set Moderation Options here


### PR DESCRIPTION
See #59 

PHP 8 fails seeking to a certain line (like in this case counting) because the flags passed are not taken in account, so it either returns 0 or a lot of lines. 

This was tested in PHP 8.0.16. To avoid writing double code i decided to take a naive approach and actually use fgetcsv() without return to move through the file since that function has no issues with our CSVs and JSON added data in cells (weird that seek() has). It works, tested on php 7.4 and 8.0.16