### PR TITLE
ISSUE-67 --> 0.3.0

### DIFF
--- a/ami.module
+++ b/ami.module
@@ -10,6 +10,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\format_strawberryfield\Event\FormatStrawberryfieldFormAlterEvent;
 use Drupal\format_strawberryfield\FormatStrawberryfieldEventType;
+use Drupal\ami\AmiUtilityService;
 
 /**
  * Implements hook_help().
@@ -129,4 +130,14 @@ function ami_form_metadatadisplay_entity_edit_form_alter(&$form,FormStateInterfa
   ];
 
   return $form;
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function ami_entity_update(Drupal\Core\Entity\EntityInterface $entity) {
+  if ($entity->getEntityTypeId() == 'ami_set_entity') {
+    // Invalidate AMI Set delete processed ADOs access check cache.
+    AmiUtilityService::invalidateAmiSetDeleteAdosAccessCache($entity);
+  }
 }

--- a/ami.module
+++ b/ami.module
@@ -141,3 +141,13 @@ function ami_entity_update(Drupal\Core\Entity\EntityInterface $entity) {
     AmiUtilityService::invalidateAmiSetDeleteAdosAccessCache($entity);
   }
 }
+
+/**
+ * Implements hook_entity_delete().
+ */
+function ami_entity_delete(Drupal\Core\Entity\EntityInterface $entity) {
+  if ($entity->getEntityTypeId() == 'ami_set_entity') {
+    // Invalidate AMI Set delete processed ADOs access check cache.
+    AmiUtilityService::invalidateAmiSetDeleteAdosAccessCache($entity);
+  }
+}

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -12,6 +12,7 @@ namespace Drupal\ami;
 use Drupal\Component\Transliteration\TransliterationInterface;
 use Drupal\Core\Archiver\ArchiverManager;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use \Drupal\Core\Entity\EntityFieldManagerInterface;
@@ -2219,6 +2220,47 @@ class AmiUtilityService {
    */
   public function cleanUpTemp(string $templocation) {
     return $this->strawberryfieldFileMetadataService->cleanUpTemp($templocation);
+  }
+
+  /**
+   * Checks the AMISet operation to determine if it's permissible to delete processed ADOs.
+   *
+   * True if the AMISet operation is not 'update' or 'patch'.
+   *
+   * @param  \Drupal\Core\Entity\EntityInterface  $entity
+   *
+   * @return bool
+   */
+  public static function checkAmiSetDeleteAdosAccess(EntityInterface $entity): bool {
+    // Deny access to delete processed ADOs when the AMI set is configured for update rather than create.
+    $cache_id = 'amiset_deleteados_access_' . $entity->id();
+    $deleteados_access = &drupal_static(__CLASS__ . __METHOD__ . $cache_id);
+    if (!isset($deleteados_access)) {
+      if ($deleteados_access_cache = \Drupal::cache()->get($cache_id)) {
+        return $deleteados_access_cache->data;
+      }
+      else {
+        $set_field = $entity->get('set');
+        if ($set_field instanceof \Drupal\strawberryfield\Field\StrawberryFieldItemList) {
+          $set = json_decode($entity->get('set')->getString(), TRUE);
+          if (json_last_error() == JSON_ERROR_NONE) {
+            $deleteados_access = (empty($set['pluginconfig']['op']) || !in_array($set['pluginconfig']['op'], ['update', 'patch']));
+            \Drupal::cache()->set($cache_id, $deleteados_access);
+          }
+        }
+      }
+    }
+    return $deleteados_access;
+  }
+
+  /**
+   * Invalidates amiset delete ADOs cache for a given AMISet entity.
+   *
+   * @param  \Drupal\Core\Entity\EntityInterface  $entity
+   */
+  public static function invalidateAmiSetDeleteAdosAccessCache(EntityInterface $entity) {
+    $cache_id = 'amiset_deleteados_access_' . $entity->id();
+    \Drupal::cache()->invalidate($cache_id);
   }
 
 }

--- a/src/Entity/Controller/amiSetEntityAccessControlHandler.php
+++ b/src/Entity/Controller/amiSetEntityAccessControlHandler.php
@@ -5,6 +5,7 @@ use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Access\AccessResult;
+use Drupal\ami\AmiUtilityService;
 
 class amiSetEntityAccessControlHandler extends EntityAccessControlHandler {
 
@@ -15,6 +16,14 @@ class amiSetEntityAccessControlHandler extends EntityAccessControlHandler {
    * $operation as defined in the routing.yml file.
    */
   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+
+    // Deny access to delete processed ADOs when the AMI set is configured for update rather than create.
+    if($operation == 'deleteados') {
+      if(!AmiUtilityService::checkAmiSetDeleteAdosAccess($entity)) {
+        return AccessResult::forbidden("Deleting processed ADOs from an update AMI set is not supported.");
+      }
+    }
+
     if ($account->hasPermission('administer amiset entity')) {
       return AccessResult::allowed()->cachePerPermissions();
     }

--- a/src/Entity/Controller/amiSetEntityListBuilder.php
+++ b/src/Entity/Controller/amiSetEntityListBuilder.php
@@ -4,6 +4,7 @@ namespace Drupal\ami\Entity\Controller;
 use Drupal\ami\amiSetEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
+use Drupal\ami\AmiUtilityService;
 
 
   /**
@@ -70,11 +71,16 @@ class amiSetEntityListBuilder extends EntityListBuilder {
         'weight' => 11,
         'url' => $this->ensureDestination($entity->toUrl('process-form')),
       ];
-      $operations['delete_processed'] = [
-        'title' => $this->t('Delete Processed ADOs'),
-        'weight' => 12,
-        'url' => $this->ensureDestination($entity->toUrl('delete-process-form')),
-      ];
+
+      // If applicable to the AMI Set, add the delete processed ADOs operation.
+      if(AmiUtilityService::checkAmiSetDeleteAdosAccess($entity)) {
+        $operations['delete_processed'] = [
+          'title' => $this->t('Delete Processed ADOs'),
+          'weight' => 12,
+          'url' => $this->ensureDestination($entity->toUrl('delete-process-form')),
+        ];
+      }
+
     }
     return $operations;
   }

--- a/src/Form/amiSetEntityDeleteProcessedForm.php
+++ b/src/Form/amiSetEntityDeleteProcessedForm.php
@@ -132,17 +132,12 @@ class amiSetEntityDeleteProcessedForm extends ContentEntityConfirmFormBase {
         'patch',
       ];
       if (in_array($op, $ops)) {
-        $form['status'] = [
-          '#tree' => TRUE,
-          '#type' => 'fieldset',
-          '#title' => $this->t(
-            'Info'
-          ),
-          '#markup' => $this->t(
-            'This AMI set is setup to perform a <em><b>@op</b></em> operation so it can not be used to delete ADOs.',
-            ['@op' => $op]
-          ),
-        ];
+        $form = $form + parent::buildForm($form, $form_state);
+        $form['actions']['submit']['#access'] = FALSE;
+        $form['description']['#markup'] = $this->t(
+          'This AMI set is configured to perform a <em><b>@op</b></em> operation so it can not be used to delete ADOs.',
+          ['@op' => $op]
+        );
         return $form;
       }
 


### PR DESCRIPTION
# What this does
- Adds access checks for AMI Set delete processed ADOs operation (with caching for performance). If an AMI set's operation is 'update' or 'patch', do not show "Delete processed ADOs in the amiset/list operations column, and do not show the "Delete Processed ADO's" link when viewing an individual AMI Set.
- Make delete processed form always return a correctly formed drupal form (though I don't think we will ever see this version of the form now, so maybe we should just delete this part of the buildForm function).

See [ISSUE-67](https://github.com/esmero/ami/issues/67).
