### PR TITLE
ISSUE-71b: Wrong logic! Fixes non-sense issue of wrong comparisson

### DIFF
--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -716,7 +716,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
   protected function processFile($data) {
 
     // First check if we already have the info here, if so do nothing.
-    if ($data->info['force_file_process'] ?? FALSE || (!$this->store->get('set_' . $data->info['set_id'] . '-' . md5($data->info['filename'])))) {
+    if (($data->info['force_file_process'] ?? FALSE) || empty($this->store->get('set_' . $data->info['set_id'] . '-' . md5($data->info['filename'])))) {
       $file = $this->AmiUtilityService->file_get($data->info['filename'],
         $data->info['zip_file']);
       if ($file) {


### PR DESCRIPTION
I made a big mistake on last pull re #71 (mistake has been around for a while) which totally skips Files IF not Forced to download them again when running it for a first time. Private stores that are empty return NULL

Comparing !(NULL) does not cast to FALSE?