### PR TITLE
ISSUE-74: Improve AMI Sets Preview

### DIFF
--- a/ami.services.yml
+++ b/ami.services.yml
@@ -13,3 +13,7 @@ services:
     arguments: [ '@file_system', '@file.usage', '@entity_type.manager', '@stream_wrapper_manager', '@plugin.manager.archiver', '@config.factory', '@current_user', '@language_manager', '@transliteration', '@module_handler', '@logger.factory', '@strawberryfield.utility', '@http_client', '@keyvalue']
     tags:
       - { name: backend_overridable }
+  ami.twig.TwigExtension:
+    class: Drupal\ami\TwigExtension
+    tags:
+      - { name: twig.extension }

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -1011,7 +1011,7 @@ class AmiUtilityService {
 
     $highestRow = count($data);
     if ($always_include_header) {
-      $rowHeaders = $data[0];
+      $rowHeaders = $data[0] ?? [];
       $rowHeaders_utf8 = array_map('stripslashes', $rowHeaders);
       $rowHeaders_utf8 = array_map('utf8_encode', $rowHeaders_utf8);
       $rowHeaders_utf8 = array_map('strtolower', $rowHeaders_utf8);

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\ami;
+
+use Twig\Markup;
+use Twig\TwigTest;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+use Twig\Extension\AbstractExtension;
+
+/**
+ * Class TwigExtension.
+ *
+ * @package Drupal\ami
+ */
+class TwigExtension extends AbstractExtension {
+
+  /**
+   * @inheritDoc
+   */
+  public function getFunctions() {
+    return [
+      new TwigFunction('ami_lod_reconcile',
+        [$this, 'amiLodReconcile']),
+    ];
+  }
+
+
+  public function amiLodReconcile(
+    string $label,
+    string $vocab,
+    string $len = 'en'
+  ): ?array {
+
+    $column_options = [
+      'loc;subjects;thing' => 'LoC subjects(LCSH)',
+      'loc;names;athing' => 'LoC Name Authority File (LCNAF)',
+      'loc;genreForms;thing' => 'LoC Genre/Form Terms (LCGFT)',
+      'loc;graphicMaterials;thing' => 'LoC Thesaurus of Graphic Materials (TGN)',
+      'loc;geographicAreas;thing' => 'LoC MARC List for Geographic Areas',
+      'loc;relators;thing' => 'LoC Relators Vocabulary (Roles)',
+      'loc;rdftype;CorporateName' => 'LoC MADS RDF by type: Corporate Name',
+      'loc;rdftype;PersonalName' => 'LoC MADS RDF by type: Personal Name',
+      'loc;rdftype;FmilyName' => 'LoC MADS RDF by type: Family Name',
+      'loc;rdftype;Topic' => 'LoC MADS RDF by type: Topic',
+      'loc;rdftype;GenreForm' =>  'LoC MADS RDF by type: Genre Form',
+      'loc;rdftype;Geographic' => 'LoC MADS RDF by type: Geographic',
+      'loc;rdftype;Temporal' =>  'LoC MADS RDF by type: Temporal',
+      'loc;rdftype;ExtraterrestrialArea' => 'LoC MADS RDF by type: Extraterrestrial Area',
+      'viaf;subjects;thing' => 'Viaf',
+      'getty;aat;fuzzy' => 'Getty aat Fuzzy',
+      'getty;aat;terms' => 'Getty aat Terms',
+      'getty;aat;exact' => 'Getty aat Exact Label Match',
+      'wikidata;subjects;thing' => 'Wikidata Q Items'
+    ];
+    $label = trim($label);
+    try {
+      $domain = \Drupal::service('request_stack')->getCurrentRequest()->getSchemeAndHttpHost();
+      $lod_route_argument_list = explode(";", $vocab);
+      $lod = \Drupal::service('ami.lod')->invokeLoDRoute($domain,
+        $label, $lod_route_argument_list[0],
+        $lod_route_argument_list[1], $lod_route_argument_list[2], $len ?? 'en', 1);
+    }
+    catch (\Exception $exception) {
+      $message = t('@exception_type thrown in @file:@line while querying for @entity_type entity ids matching "@label". Message: @response',
+        [
+          '@exception_type' => get_class($exception),
+          '@file' => $exception->getFile(),
+          '@line' => $exception->getLine(),
+          '@label' => $label,
+          '@response' => $exception->getMessage(),
+        ]);
+      \Drupal::logger('ami')->warning($message);
+      return NULL;
+    }
+
+    if (!empty($lod)) {
+      return $lod;
+    }
+    return NULL;
+  }
+}


### PR DESCRIPTION
See #74 

Includes now `{{ data_lod }}` into the Preview Functionality of AMI Sets including the actual data for the chose row and also empties (referential empties since those will not exist during the ingest, FYI, THAT IS GOOD believe me DO NOT FIGHT ME) 

and a new Twig Extension mean to be used ONLY for ingests and NOT in realtime calls.. I can even be "Dense" about this and cut it out in case the call is happening from an /ado/route .. ok? Be nice, only use it during ingest or donate to WIKIDATA and LoC

Uses one of these (there are a few more! but not documented yet...hehehe.. hint .. nominatim )

      'loc;subjects;thing' => 'LoC subjects(LCSH)',
      'loc;names;athing' => 'LoC Name Authority File (LCNAF)',
      'loc;genreForms;thing' => 'LoC Genre/Form Terms (LCGFT)',
      'loc;graphicMaterials;thing' => 'LoC Thesaurus of Graphic Materials (TGN)',
      'loc;geographicAreas;thing' => 'LoC MARC List for Geographic Areas',
      'loc;relators;thing' => 'LoC Relators Vocabulary (Roles)',
      'loc;rdftype;CorporateName' => 'LoC MADS RDF by type: Corporate Name',
      'loc;rdftype;PersonalName' => 'LoC MADS RDF by type: Personal Name',
      'loc;rdftype;FmilyName' => 'LoC MADS RDF by type: Family Name',
      'loc;rdftype;Topic' => 'LoC MADS RDF by type: Topic',
      'loc;rdftype;GenreForm' =>  'LoC MADS RDF by type: Genre Form',
      'loc;rdftype;Geographic' => 'LoC MADS RDF by type: Geographic',
      'loc;rdftype;Temporal' =>  'LoC MADS RDF by type: Temporal',
      'loc;rdftype;ExtraterrestrialArea' => 'LoC MADS RDF by type: Extraterrestrial Area',
      'viaf;subjects;thing' => 'Viaf',
      'getty;aat;fuzzy' => 'Getty aat Fuzzy',
      'getty;aat;terms' => 'Getty aat Terms',
      'getty;aat;exact' => 'Getty aat Exact Label Match',
      'wikidata;subjects;thing' => 'Wikidata Q Items'

To be called like this

` {{ ami_lod_reconcile('Central Park', 'loc;subjects;thing',  'en')|json_encode|raw }}` 

Return will be either NULL (if none found)
or an array in this form

`[{"uri":"http:\/\/id.loc.gov\/authorities\/subjects\/sh85021920","label":"Central Park (New York, N.Y.)"}]`

