### PR TITLE
ISSUE-80: Make AMI LOD Twig extension signature more flexible

### DIFF
--- a/src/AmiLoDService.php
+++ b/src/AmiLoDService.php
@@ -346,15 +346,28 @@ class AmiLoDService {
       // tricky? Our request has the arguments + the method takes the same
       // Just for compatibility since route collection manager
       // Does that automatically on a real public request.
-      $controller_url = Url::fromRoute(
-        'webform_strawberryfield.nominatim',
-        ['api_type' => 'search', 'count' => 1, 'lang' => $current_laguage],
-        ['query' => ['q' => $query]]
-      );
+      if (in_array($rdftype, ['thing', 'search'])){
+        $controller_url = Url::fromRoute(
+          'webform_strawberryfield.nominatim',
+          ['api_type' => 'search', 'count' => 1, 'lang' => $current_laguage],
+          ['query' => ['q' => $query]]
+        );
+      }
+      elseif ($rdftype == 'reverse') {
+        [$lat, $long] = explode(",", $query, 2);
+        $controller_url = Url::fromRoute(
+          'webform_strawberryfield.nominatim',
+          ['api_type' => 'reverse', 'count' => 1, 'lang' => $current_laguage],
+          ['query' => ['lat' => $lat, 'lon' => $long]]
+        );
+      }
+      else {
+        return [];
+      }
 
       $json_response = $controller_nominatim->handleRequest(
         Request::create($controller_url->toString(), 'GET'),
-        'search',
+        $rdftype,
         1,
         $current_laguage
       );

--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -319,7 +319,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
     // A Smart twig template that adds extra mappings
     // This decode will always work because we already decoded and encoded again.
     $processed_metadata = json_decode($processed_metadata, TRUE);
-
+    $processed_metadata['ap:entitymapping'] = is_array($processed_metadata['ap:entitymapping']) ? $processed_metadata['ap:entitymapping'] : [];
     $custom_file_mapping = isset($processed_metadata['ap:entitymapping']['entity:file']) && is_array($processed_metadata['ap:entitymapping']['entity:file']) ? $processed_metadata['ap:entitymapping']['entity:file'] : [];
     $custom_node_mapping = isset($processed_metadata['ap:entitymapping']['entity:node']) && is_array($processed_metadata['ap:entitymapping']['entity:node']) ? $processed_metadata['ap:entitymapping']['entity:node'] : [];
 

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -26,13 +26,20 @@ class TwigExtension extends AbstractExtension {
   }
 
 
+  /**
+   * @param mixed $label
+   * @param string $vocab
+   * @param string $len
+   *
+   * @return array|null
+   */
   public function amiLodReconcile(
-    string $label,
+    $label,
     string $vocab,
     string $len = 'en'
   ): ?array {
 
-    $column_options = [
+    $vocaboptions = [
       'loc;subjects;thing' => 'LoC subjects(LCSH)',
       'loc;names;athing' => 'LoC Name Authority File (LCNAF)',
       'loc;genreForms;thing' => 'LoC Genre/Form Terms (LCGFT)',
@@ -51,9 +58,18 @@ class TwigExtension extends AbstractExtension {
       'getty;aat;fuzzy' => 'Getty aat Fuzzy',
       'getty;aat;terms' => 'Getty aat Terms',
       'getty;aat;exact' => 'Getty aat Exact Label Match',
-      'wikidata;subjects;thing' => 'Wikidata Q Items'
+      'wikidata;subjects;thing' => 'Wikidata Q Items',
+      'nominatim;thing;thing' => 'Nominatim Search',
+      'nominatim;thing;search' => 'Nominatim Search',
+      'nominatim;thing;reverse' => 'Nominatim Reverse'
     ];
+    if (!in_array($vocab, array_keys($vocaboptions)) || empty($label) || !is_scalar($label) || is_bool($label)) {
+      return [];
+    }
     $label = trim($label);
+    if (strlen($label) == 0) {
+      return [];
+    }
     try {
       $domain = \Drupal::service('request_stack')->getCurrentRequest()->getSchemeAndHttpHost();
       $lod_route_argument_list = explode(";", $vocab);


### PR DESCRIPTION
See #80 for the full explanation

This also adds reverse `nominatim` capabilities to our AMI LOD Service and to the extension of course in this form:

e.g usage is:
```Twig
{% set coordinates = "40.749778,-73.977618" %}
{% set nominatim = ami_lod_reconcile(coordinates, "nominatim;thing;reverse", "en", 1) %}
```