### PR TITLE
ISSUE-84 and ISSUE-83

### DIFF
--- a/src/AmiBatchQueue.php
+++ b/src/AmiBatchQueue.php
@@ -76,7 +76,8 @@ class AmiBatchQueue {
         $num_of_items = $queue->numberOfItems();
 
         // Update context
-        $context['results']['processed'][] = $item->item_id;
+        // Redis Queues do not have item_id!
+        $context['results']['processed'][] = $item->item_id ?? $ado_title;
         $context['finished'] = ($context['sandbox']['max'] - $num_of_items) / $context['sandbox']['max'];
       }
       else {

--- a/src/AmiLoDBatchQueue.php
+++ b/src/AmiLoDBatchQueue.php
@@ -66,7 +66,7 @@ class AmiLoDBatchQueue {
         $num_of_items = $queue->numberOfItems();
 
         // Update context
-        $context['results']['processed'][] = $item->item_id;
+        $context['results']['processed'][] = $item->item_id ?? $label;
         $context['finished'] = ($context['sandbox']['max'] - $num_of_items) / $context['sandbox']['max'];
       }
       else {

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -448,8 +448,9 @@ class AmiUtilityService {
   ) {
     // pre set a failure
     $parsed_url = parse_url($uri);
+    $basename = $this->fileSystem->basename(urldecode($parsed_url['path']));
     if (!isset($destination)) {
-      $path = file_build_uri($this->fileSystem->basename(urldecode($parsed_url['path'])));
+      $path = file_build_uri($basename);
     }
     else {
       if (is_dir($this->fileSystem->realpath($destination))) {
@@ -457,11 +458,12 @@ class AmiUtilityService {
         $path = str_replace(
             '///',
             '//',
-            "{$destination}/"
-          ) . $this->fileSystem->basename(urldecode($parsed_url['path']));
+            "{$destination}"
+          ) . $basename;
       }
       else {
         $path = $destination;
+        $basename = $this->fileSystem->basename($destination);
       }
     }
     /* @var \Psr\Http\Message\ResponseInterface $response */
@@ -475,12 +477,11 @@ class AmiUtilityService {
         $max_time = 720.00;
       }
       $response = $this->httpClient->get($uri, ['sink' => $path, 'timeout' => round($max_time,2)]);
-      $content_disposition = $response->getHeader('Content-Disposition');
-      $filename_from_remote = NULL;
-      $filename_from_remote_without_extension = NULL;
-      $extensions_from_remote = NULL;
+      $filename_from_remote = $basename;
+      [$filename_from_remote_without_extension, $extensions_from_remote] = explode(".", $basename, 2);
       $extension_from_mime = NULL;
       $extension = NULL;
+      $content_disposition = $response->getHeader('Content-Disposition');
 
       if (!empty($content_disposition)) {
         $filename_from_remote = $this->getFilenameFromDisposition($content_disposition[0]);
@@ -516,7 +517,7 @@ class AmiUtilityService {
       $mimefromextension = \Drupal::service('strawberryfield.mime_type.guesser.mime')
         ->guess($filename_from_remote ?? $path);
       if (($mimefromextension == "application/octet-stream")) {
-        $extension = $extensions_from_remote ?? '';
+        $extension = $extensions_from_remote ?? 'bin';
       }
     }
     if ($filename_from_remote_without_extension) {
@@ -1172,8 +1173,8 @@ class AmiUtilityService {
       SplFileObject::DROP_NEW_LINE
     );
     while (!$spl->eof()) {
-       $spl->fgetcsv();
-       $key = $spl->key();
+      $spl->fgetcsv();
+      $key = $spl->key();
     }
 
     /*
@@ -1329,12 +1330,12 @@ class AmiUtilityService {
    */
   public function getWebformOptions():array {
     try {
-    /** @var \Drupal\webform\WebformOptionsInterface[] $webform_options */
-    $webform_options  = $this->entityTypeManager->getStorage('webform_options')->loadByProperties(['category' => 'archipelago']);
-    $options = [];
-    foreach($webform_options as $webform_option) {
-      $options = array_merge($options, $webform_option->getOptions());
-    }
+      /** @var \Drupal\webform\WebformOptionsInterface[] $webform_options */
+      $webform_options  = $this->entityTypeManager->getStorage('webform_options')->loadByProperties(['category' => 'archipelago']);
+      $options = [];
+      foreach($webform_options as $webform_option) {
+        $options = array_merge($options, $webform_option->getOptions());
+      }
     }
     catch (\Exception $e) {
       // Return some basic defaults in case there are no Options.
@@ -2127,6 +2128,7 @@ class AmiUtilityService {
       // get the mappings for this set if any
       // @TODO Refactor into a Method?
       $lod_mappings = $this->AmiLoDService->getKeyValueMappingsPerAmiSet($set_id);
+      /* @TODO refactor into a reusable method */
       if ($lod_mappings) {
         foreach($lod_mappings as $source_column => $destination) {
           if (isset($context['data'][$source_column])) {
@@ -2141,6 +2143,9 @@ class AmiUtilityService {
                 foreach ($lod_for_label as $approach => $lod) {
                   if (isset($lod['lod'])) {
                     $context_lod[$source_column][$approach] = array_merge($context_lod[$source_column][$approach] ?? [], $lod['lod']);
+                    $serialized = array_map('serialize', $context_lod[$source_column][$approach]);
+                    $unique = array_unique($serialized);
+                    $context_lod[$source_column][$approach] = array_intersect_key($context_lod[$source_column][$approach], $unique);
                   }
                 }
               }

--- a/src/Controller/AmiRowAutocompleteHandler.php
+++ b/src/Controller/AmiRowAutocompleteHandler.php
@@ -218,6 +218,9 @@ class AmiRowAutocompleteHandler extends ControllerBase {
                       if (isset($lod['lod'])) {
                         $context_lod[$source_column][$approach] = array_merge($context_lod[$source_column][$approach] ?? [],
                           $lod['lod']);
+                        $serialized = array_map('serialize', $context_lod[$source_column][$approach]);
+                        $unique = array_unique($serialized);
+                        $context_lod[$source_column][$approach] = array_intersect_key($context_lod[$source_column][$approach], $unique);
                       }
                     }
                   }

--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -319,7 +319,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
     // A Smart twig template that adds extra mappings
     // This decode will always work because we already decoded and encoded again.
     $processed_metadata = json_decode($processed_metadata, TRUE);
-    $processed_metadata['ap:entitymapping'] = is_array($processed_metadata['ap:entitymapping']) ? $processed_metadata['ap:entitymapping'] : [];
+    $processed_metadata['ap:entitymapping'] = isset($processed_metadata['ap:entitymapping']) && is_array($processed_metadata['ap:entitymapping']) ? $processed_metadata['ap:entitymapping'] : [];
     $custom_file_mapping = isset($processed_metadata['ap:entitymapping']['entity:file']) && is_array($processed_metadata['ap:entitymapping']['entity:file']) ? $processed_metadata['ap:entitymapping']['entity:file'] : [];
     $custom_node_mapping = isset($processed_metadata['ap:entitymapping']['entity:node']) && is_array($processed_metadata['ap:entitymapping']['entity:node']) ? $processed_metadata['ap:entitymapping']['entity:node'] : [];
 


### PR DESCRIPTION
See #84 and #83 

The largest thing here was the wrong extension/naming of remote files without a content disposition (which we neglected to use at all in 0.3.0 and 0.2.0 so was not even an issue). This will fix remotes coming from e.g `islandora/object/pid:1/OBJ/view` instead of download

There is an extra benefit on all of this, extensions are being normalized now if we know the mime type and I did a small optimization too!

@alliomeria @karomabiles hope this helps!