### PR TITLE
ISSUE-84b: Files might not have an extension at all!

### DIFF
--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -699,7 +699,7 @@ class AmiUtilityService {
    * @param string $value
    *
    * @return string|null
-   *    Returns NULL if could not be parsed
+   *    Returns NULL if could not be parsed/empty
    */
   protected function getFilenameFromDisposition(string $value) {
     $value = trim($value);

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -478,7 +478,9 @@ class AmiUtilityService {
       }
       $response = $this->httpClient->get($uri, ['sink' => $path, 'timeout' => round($max_time,2)]);
       $filename_from_remote = $basename;
-      [$filename_from_remote_without_extension, $extensions_from_remote] = explode(".", $basename, 2);
+      $filename_from_remote_parts = explode(".", $basename, 2);
+      $filename_from_remote_without_extension = $filename_from_remote_parts[0] ?? NULL;
+      $extensions_from_remote = $filename_from_remote_parts[1] ?? NULL;
       $extension_from_mime = NULL;
       $extension = NULL;
       $content_disposition = $response->getHeader('Content-Disposition');
@@ -488,7 +490,9 @@ class AmiUtilityService {
         if ($filename_from_remote) {
           // we want the name without extension, we do not trust the extension
           // See remote sources with double extension!
-          [$filename_from_remote_without_extension, $extensions_from_remote] = explode(".", $filename_from_remote, 2);
+          $filename_from_remote_parts = explode(".", $filename_from_remote, 2);
+          $filename_from_remote_without_extension = $filename_from_remote_parts[0] ?? NULL;
+          $extensions_from_remote = $filename_from_remote_parts[1] ?? NULL;
         }
       }
     }


### PR DESCRIPTION
# What?

Well I did not solved the WHOLE issue on my last pull. This fixes the last warning `[$filename_from_remote_without_extension, $extensions_from_remote] = explode(".", $basename, 2);`
Is a bad idea if we do not know if there are actually  at least 2 part, so went the most traditional way with checks and more checks