### PR TITLE
ISSUE-90: Fixes state/moderation when updating draft ingested Objects

### DIFF
--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -569,15 +569,16 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
         'uid' =>  $data->info['uid'],
         $field_name => $jsonstring
       ];
-      if ($status && is_string($status)) {
-        // String here means we got moderation_status;
-        $nodeValues['moderation_state'] = $status;
-        $status = 0; // Let the Moderation Module set the right value
-      }
+
 
       /** @var \Drupal\Core\Entity\EntityPublishedInterface $node */
       try {
         if ($op ==='create') {
+          if ($status && is_string($status)) {
+            // String here means we got moderation_status;
+            $nodeValues['moderation_state'] = $status;
+            $status = 0; // Let the Moderation Module set the right value
+          }
           $node = $this->entityTypeManager->getStorage('node')
             ->create($nodeValues);
         }


### PR DESCRIPTION
See #90 

I was improperly checking the moderation state before deciding if I needed to ingest/update, leaving the following operation as an impossible

- Ingested as Draft
- Updated and made Published

This is a small fix that deals with Create/Update as separate cases. Tested