### PR TITLE
ISSUE-93: New Update logic

### DIFF
--- a/ami.module
+++ b/ami.module
@@ -4,10 +4,10 @@
  * Contains ami.module.
  */
 
-use Drupal\Core\Language\Language;
+use Drupal\ami\AmiEventType;
+use Drupal\ami\Event\AmiCrudEvent;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Url;
 use Drupal\format_strawberryfield\Event\FormatStrawberryfieldFormAlterEvent;
 use Drupal\format_strawberryfield\FormatStrawberryfieldEventType;
 use Drupal\ami\AmiUtilityService;
@@ -149,5 +149,19 @@ function ami_entity_delete(Drupal\Core\Entity\EntityInterface $entity) {
   if ($entity->getEntityTypeId() == 'ami_set_entity') {
     // Invalidate AMI Set delete processed ADOs access check cache.
     AmiUtilityService::invalidateAmiSetDeleteAdosAccessCache($entity);
+    // Remove any AMI LoD Key Values.
+    \Drupal::service('ami.lod')->cleanKeyValuesPerAmiSet($entity->id());
+  }
+}
+
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function ami_ami_set_entity_presave(Drupal\Core\Entity\EntityInterface $entity) {
+  if ($sbf_fields = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($entity)) {
+    $event_type = AmiEventType::PRESAVE;
+    $event = new AmiCrudEvent($event_type, $entity, $sbf_fields);
+    \Drupal::service('event_dispatcher')->dispatch($event_type, $event);
   }
 }

--- a/ami.services.yml
+++ b/ami.services.yml
@@ -17,3 +17,8 @@ services:
     class: Drupal\ami\TwigExtension
     tags:
       - { name: twig.extension }
+  ami.presaveprocesslod_subscriber:
+    class: Drupal\ami\EventSubscriber\AmiEventPresaveSubscriberProcessedLoDUpdater
+    tags:
+      - { name: event_subscriber }
+    arguments: [ '@string_translation', '@messenger', '@logger.factory', '@current_user', '@ami.utility', '@entity_type.manager', '@ami.lod']

--- a/src/AmiEventType.php
+++ b/src/AmiEventType.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace Drupal\ami;
+
+/**
+ * Class AmiEventType.
+ *
+ * @package Drupal\ami
+ */
+final class AmiEventType {
+
+  /**
+   * Name of the event fired when pre saving an AMI Entity.
+   *
+   * This event allows modules to perform an action whenever an AMI
+   * is saved. The event listener method receives a
+   * \Drupal\ami\Event\AmiCrudEvent instance.
+   *
+   * @Event
+   *
+   * @see ami_ami_set_entity_presave()
+   * @see \Drupal\ami\Event\AmiCrudEvent
+   * @see \Drupal\ami\EventSubscriber\AmiEventPresaveSubscriberProcessedLoDUpdater
+   *
+   * @var string
+   */
+  const PRESAVE = 'ami.ami_set_entity.presave';
+
+
+}

--- a/src/AmiLoDService.php
+++ b/src/AmiLoDService.php
@@ -142,6 +142,49 @@ class AmiLoDService {
    */
   protected $keyValue;
 
+  public CONST AMI_FORM_EXPOSED_LOD_SOURCES =  [
+    'loc;subjects;thing' => 'LoC subjects(LCSH)',
+    'loc;names;thing' => 'LoC Name Authority File (LCNAF)',
+    'loc;genreForms;thing' => 'LoC Genre/Form Terms (LCGFT)',
+    'loc;graphicMaterials;thing' => 'LoC Thesaurus of Graphic Materials (TGN)',
+    'loc;geographicAreas;thing' => 'LoC MARC List for Geographic Areas',
+    'loc;relators;thing' => 'LoC Relators Vocabulary (Roles)',
+    'loc;rdftype;CorporateName' => 'LoC MADS RDF by type: Corporate Name',
+    'loc;rdftype;PersonalName' => 'LoC MADS RDF by type: Personal Name',
+    'loc;rdftype;FamilyName' => 'LoC MADS RDF by type: Family Name',
+    'loc;rdftype;Topic' => 'LoC MADS RDF by type: Topic',
+    'loc;rdftype;GenreForm' =>  'LoC MADS RDF by type: Genre Form',
+    'loc;rdftype;Geographic' => 'LoC MADS RDF by type: Geographic',
+    'loc;rdftype;Temporal' =>  'LoC MADS RDF by type: Temporal',
+    'loc;rdftype;ExtraterrestrialArea' => 'LoC MADS RDF by type: Extraterrestrial Area',
+    'viaf;subjects;thing' => 'Viaf',
+    'getty;aat;fuzzy' => 'Getty aat Fuzzy',
+    'getty;aat;terms' => 'Getty aat Terms',
+    'getty;aat;exact' => 'Getty aat Exact Label Match',
+    'wikidata;subjects;thing' => 'Wikidata Q Items'
+  ];
+
+  public CONST LOD_COLUMN_TO_ARGUMENTS = [
+    'loc_subjects_thing' => 'loc;subjects;thing',
+    'loc_names_thing' => 'loc;names;thing',
+    'loc_genreforms_thing' => 'loc;genreForms;thing',
+    'loc_graphicmaterials_thing' => 'loc;graphicMaterials;thing',
+    'loc_geographicareas_thing' => 'loc;geographicAreas;thing',
+    'loc_relators_thing' => 'loc;relators;thing',
+    'loc_rdftype_corporatename' => 'loc;rdftype;CorporateName',
+    'loc_rdftype_personalname' =>  'loc;rdftype;PersonalName',
+    'loc_rdftype_familyname' => 'loc;rdftype;FamilyName',
+    'loc_rdftype_topic' => 'loc;rdftype;Topic',
+    'loc_rdftype_genreform' =>  'loc;rdftype;GenreForm',
+    'loc_rdftype_geographic' => 'loc;rdftype;Geographic',
+    'loc_rdftype_temporal' =>  'loc;rdftype;Temporal',
+    'loc_rdftype_extraterrestrialarea' => 'loc;rdftype;ExtraterrestrialArea',
+    'viaf_subjects_thing' => 'viaf;subjects;thing',
+    'getty_aat_fuzzy' => 'getty;aat;fuzzy',
+    'getty_aat_terms' => 'getty;aat;terms',
+    'getty_aat_exact' => 'getty;aat;exact',
+    'wikidata_subjects_thing' => 'wikidata;subjects;thing'
+  ];
 
   /**
    * AmiLoDService constructor.

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -1037,6 +1037,9 @@ class AmiUtilityService {
         SplFileObject::SKIP_EMPTY |
         SplFileObject::DROP_NEW_LINE
       );
+      if (!$escape_characters) {
+        $spl->setCsvControl(',', '"', "");
+      }
     }
 
     if ($offset > 0 && !$always_include_header) {
@@ -1091,8 +1094,8 @@ class AmiUtilityService {
         $row = $row ?? [];
         $flat = trim(implode('', $row));
         //check for empty row...if found stop there.
+        $maxRow = $rowindex;
         if (strlen($flat) == 0) {
-          $maxRow = $rowindex;
           break;
         }
         // This was done already by the Import Plugin but since users

--- a/src/Event/AmiCrudEvent.php
+++ b/src/Event/AmiCrudEvent.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\ami\Event;
+
+use Drupal\Component\EventDispatcher\Event;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Class to contain an Ami Entity entity event.
+ */
+class AmiCrudEvent extends Event{
+
+  /**
+   * The Entity.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  private $entity;
+
+  /**
+   * The SBF field machine names.
+   *
+   * @array;
+   */
+  private $fields;
+
+  /**
+   * The event type.
+   *
+   * @var \Drupal\ami\AmiEventType
+   */
+  private $eventType;
+
+  /**
+   * Which Subscribers processed this Event
+   *
+   * @var array
+   *
+   */
+  private $processedby = [];
+
+  /**
+   * Construct a new entity event.
+   *
+   * @param string                              $event_type
+   *   The event type.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity which caused the event.
+   * @param array                               $sbfFields
+   * @param array                               $processedby
+   */
+  public function __construct($event_type, EntityInterface $entity,
+    array $sbfFields, array $processedby = []
+  ) {
+    $this->entity = $entity;
+    $this->eventType = $event_type;
+    $this->fields = $sbfFields;
+    $this->processedby = $processedby;
+  }
+
+  /**
+   * Method to get the entity from the event.
+   */
+  public function getEntity() {
+    return $this->entity;
+  }
+
+  /**
+   * Method to get the fields from the event.
+   */
+  public function getFields() {
+    return $this->fields;
+  }
+
+  /**
+   * Method to get the event type.
+   */
+  public function getEventType() {
+    return $this->eventType;
+  }
+
+  /**
+   * Method to get the all Subscribers that processed this in the past.
+   */
+  public function getProcessedBy() {
+    return $this->processedby;
+  }
+
+  /**
+   * Method to get the append a Subscriber's processed state.
+   *
+   * @param string $class
+   * @param bool   $success
+   *
+   * @return array
+   */
+  public function setProcessedBy(string $class, bool $success) {
+    return $this->processedby[] = ['class' => $class, 'success' => $success];
+  }
+
+}

--- a/src/EventSubscriber/AmiEventPresaveSubscriber.php
+++ b/src/EventSubscriber/AmiEventPresaveSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\ami\EventSubscriber;
+
+use Drupal\ami\AmiEventType;
+use Drupal\ami\Event\AmiCrudEvent;
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for AMI entity presave event.
+ */
+abstract class AmiEventPresaveSubscriber implements EventSubscriberInterface {
+
+  /**
+   * @var int
+   */
+  protected static $priority = -800;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // Make sure we have access before everything else here since we want
+    // Enrich our JSON before anything runs.
+    // @TODO check event priority and adapt to future D9 needs.
+    // Use late binding. Never use self:: or we will all get -800 in every class.
+    $events[AmiEventType::PRESAVE][] = ['onEntityPresave', static::$priority];
+    return $events;
+  }
+
+
+    /**
+   * Method called when Event occurs.
+   *
+   * @param \Drupal\ami\Event\AmiCrudEvent $event
+   *   The event.
+   */
+  abstract public function onEntityPresave(AmiCrudEvent $event);
+
+}

--- a/src/EventSubscriber/AmiEventPresaveSubscriberProcessedLoDUpdater.php
+++ b/src/EventSubscriber/AmiEventPresaveSubscriberProcessedLoDUpdater.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Drupal\ami\EventSubscriber;
+
+use Drupal\ami\AmiLoDService;
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\ami\AmiEventType;
+use Drupal\ami\Event\AmiCrudEvent;
+use Drupal\ami\AmiUtilityService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Event subscriber for AMI entity presave event, injects CSV LoD into keystore.
+ */
+class AmiEventPresaveSubscriberProcessedLoDUpdater extends AmiEventPresaveSubscriber {
+
+  use StringTranslationTrait;
+
+  /**
+   * @var int
+   */
+  protected static $priority = -900;
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The Storage Destination Scheme.
+   *
+   * @var string;
+   */
+  protected $destinationScheme = NULL;
+
+  /**
+   * The logger factory.
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
+  /**
+   * @var \Drupal\ami\AmiUtilityService
+   */
+  protected $AmiUtilityService;
+
+  /**
+   * The entity manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * @var \Drupal\ami\AmiLoDService
+   */
+  protected $AmiLoDService;
+
+  /**
+   * StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata constructor.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   * @param \Drupal\ami\AmiUtilityService $ami_utility
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\ami\AmiLoDService $ami_lod,
+   */
+  public function __construct(
+    TranslationInterface $string_translation,
+    MessengerInterface $messenger,
+    LoggerChannelFactoryInterface $logger_factory,
+    AccountInterface $account,
+    AmiUtilityService $ami_utility,
+    EntityTypeManagerInterface $entity_type_manager,
+    AmiLoDService $ami_lod
+  ) {
+    $this->stringTranslation = $string_translation;
+    $this->messenger = $messenger;
+    $this->loggerFactory = $logger_factory;
+    $this->account = $account;
+    $this->AmiUtilityService = $ami_utility;
+    $this->AmiLoDService = $ami_lod;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+
+  /**
+   * @param \Drupal\ami\Event\AmiCrudEvent $event
+   */
+  public function onEntityPresave(AmiCrudEvent $event) {
+
+    /* @var $entity \Drupal\ami\Entity\AmiSetEntity */
+    $entity = $event->getEntity();
+    $sbf_fields = $event->getFields();
+    $originallabel = NULL;
+    $forceupdate = TRUE;
+    if (!$entity->isNew()) {
+      $originalLodCSV = $entity->original->processed_data->getValue();
+      $newLodCSV = $entity->processed_data->getValue();
+      $originalLodCSV = $originalLodCSV[0]['target_id'] ?? null;
+      $newLodCSV = $newLodCSV[0]['target_id'] ?? null;
+      // Only act on changes on the processed CSV. We do not want to execute
+      // this costly operation on every save.
+      if (($originalLodCSV != $newLodCSV) && !empty($newLodCSV)) {
+        $lod_options = array_keys(AmiLoDService::LOD_COLUMN_TO_ARGUMENTS);
+        $enforced_headers = ['original','csv_columns', 'checked'];
+        $csv_file_reference = $entity->get('source_data')->getValue();
+        /** @var \Drupal\file\Entity\File $file */
+        $file_lod = $this->entityTypeManager->getStorage('file')->load(
+          $newLodCSV
+        );
+        // We avoid the escape characters here to allow JSON with double quotes
+        // In its values to be read from the CSV.
+        if ($file_lod) {
+          $file_data_all = $this->AmiUtilityService->csv_read(
+            $file_lod, 0, 0, TRUE, FALSE
+          );
+          $header = $file_data_all['headers'] ?? [];
+          // Validation is not done here
+          $required_headers = ['original','csv_columns', 'checked'];
+
+          // Clears old values before processing new ones.
+          $this->AmiLoDService->cleanKeyValuesPerAmiSet($entity->id());
+          $update_config = FALSE;
+          $normalized_mapping = [];
+          if (count($file_data_all['data']) > 0) {
+            foreach ($file_data_all['data'] as $rownumber => $row) {
+              $keyed_row = array_combine($header, $row);
+              $label = $keyed_row['original'] ?? NULL;
+              $csv_columns = json_decode($keyed_row['csv_columns'], TRUE);
+              // If these do not exist, we can not process.
+              if (!$label || !$csv_columns) {
+                $this->loggerFactory->get('ami')->warning(
+                  "Uploaded LoD CSV for AMI Set @ami_set_label on row @row had missing required values for csv_columns and/or label. Skipping",
+                  [
+                    '@ami_set_label' => $entity->label(),
+                    '@row'           => $rownumber,
+                  ]
+                );
+                continue;
+              }
+              foreach ($keyed_row as $column => $value) {
+                if (!in_array($column, $required_headers)
+                  && in_array(
+                    $column, $lod_options
+                  )
+                ) {
+                  $lod = json_decode($value, TRUE);
+                  if ($lod) {
+                    foreach ($csv_columns as $source_column) {
+                      $normalized_mapping[$source_column][] = $column;
+                      $normalized_mapping[$source_column] = array_unique(
+                        $normalized_mapping[$source_column]
+                      );
+                    }
+                  }
+                  $context_data[$column]['lod'] = $lod ?? NULL;
+                  $context_data[$column]['columns'] = $csv_columns;
+                  $context_data['checked'] = $keyed_row['checked'] ?? FALSE;
+                }
+              }
+              $this->AmiLoDService->setKeyValuePerAmiSet(
+                $label,
+                $context_data, $entity->id()
+              );
+            }
+
+            // This happen in reverse order as in \Drupal\ami\Form\amiSetEntityReconcileCleanUpForm::submitForm
+            // given than mappings are deduced from the actual ROW data of the CSV
+            $this->AmiLoDService->setKeyValueMappingsPerAmiSet(
+              $normalized_mapping, $entity->id()
+            );
+            $update_config = TRUE;
+          }
+        }
+
+      if ($update_config) {
+        foreach ($sbf_fields as $field_name) {
+          /* @var $field \Drupal\Core\Field\FieldItemInterface */
+          $field = $entity->get($field_name);
+          /* @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
+          // This will try with any possible match.
+          foreach ($field->getIterator() as $delta => $itemfield) {
+            $fullvalues = $itemfield->provideDecoded(TRUE);
+            $fullvalues["reconcileconfig"]["columns"] = [];
+            $fullvalues["reconcileconfig"]["mappings"] = [];
+            $fullvalues["reconcileconfig"]["columns"] = array_combine(array_keys($normalized_mapping), array_keys($normalized_mapping));
+            foreach ($normalized_mapping as $source => $approaches) {
+              foreach ($approaches as $approach) {
+                $fullvalues["reconcileconfig"]["mappings"][$source][]
+                  = $this->AmiLoDService::LOD_COLUMN_TO_ARGUMENTS[$approach];
+                }
+              $fullvalues["reconcileconfig"]["mappings"][$source] = array_unique($fullvalues["reconcileconfig"]["mappings"][$source]);
+            }
+
+            if (!$itemfield->setMainValueFromArray((array) $fullvalues)) {
+              $this->messenger->addError($this->t('We could not persist LoD Configuration inferred from the CSV. Please contact the site admin.'));
+            }
+          }
+        }
+      }
+    }
+    $current_class = get_called_class();
+    $event->setProcessedBy($current_class, TRUE);
+  }
+}
+}

--- a/src/Form/amiSetEntityForm.php
+++ b/src/Form/amiSetEntityForm.php
@@ -28,7 +28,7 @@ class amiSetEntityForm extends ContentEntityForm {
   public function save(array $form, FormStateInterface $form_state) {
     $status = parent::save($form, $form_state);
     $entity = $this->entity;
-    $form_state->setRedirectUrl($entity->toUrl('collection'));
+    $form_state->setRedirectUrl($entity->toUrl('canonical'));
     return $status;
   }
 }

--- a/src/Form/amiSetEntityReconcileCleanUpForm.php
+++ b/src/Form/amiSetEntityReconcileCleanUpForm.php
@@ -19,28 +19,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class amiSetEntityReconcileCleanUpForm extends ContentEntityConfirmFormBase {
 
-
-  CONST LOD_COLUMN_TO_ARGUMENTS = [
-    'loc_subjects_thing' => 'loc;subjects;thing',
-    'loc_names_thing' => 'loc;names;thing',
-    'loc_genreforms_thing' => 'loc;genreForms;thing',
-    'loc_graphicmaterials_thing' => 'loc;graphicMaterials;thing',
-    'loc_geographicareas_thing' => 'loc;geographicAreas;thing',
-    'loc_relators_thing' => 'loc;relators;thing',
-    'loc_rdftype_corporatename' => 'loc;rdftype;CorporateName',
-    'loc_rdftype_personalname' =>  'loc;rdftype;PersonalName',
-    'loc_rdftype_familyname' => 'loc;rdftype;FamilyName',
-    'loc_rdftype_topic' => 'loc;rdftype;Topic',
-    'loc_rdftype_genreform' =>  'loc;rdftype;GenreForm',
-    'loc_rdftype_geographic' => 'loc;rdftype;Geographic',
-    'loc_rdftype_temporal' =>  'loc;rdftype;Temporal',
-    'loc_rdftype_extraterrestrialarea' => 'loc;rdftype;ExtraterrestrialArea',
-    'viaf_subjects_thing' => 'viaf;subjects;thing',
-    'getty_aat_fuzzy' => 'getty;aat;fuzzy',
-    'getty_aat_terms' => 'getty;aat;terms',
-    'getty_aat_exact' => 'getty;aat;exact',
-    'wikidata_subjects_thing' => 'wikidata;subjects;thing'
-  ];
   /**
    * @var \Drupal\ami\AmiUtilityService
    */
@@ -214,7 +192,7 @@ class amiSetEntityReconcileCleanUpForm extends ContentEntityConfirmFormBase {
 
           foreach ($column_keys as $column) {
             if ($column !== 'original' && $column != 'csv_columns' && $column !='checked') {
-              $argument_string = static::LOD_COLUMN_TO_ARGUMENTS[$column] ?? NULL;
+              $argument_string = $this->AmiLoDService::LOD_COLUMN_TO_ARGUMENTS[$column] ?? NULL;
               if ($argument_string) {
                 $arguments = explode(';', $argument_string);
                 $elements[$column] = [
@@ -338,16 +316,20 @@ class amiSetEntityReconcileCleanUpForm extends ContentEntityConfirmFormBase {
         $csv_columns = json_decode($csv_columns, TRUE);
         // If these do not exist, we can not process.
         if ($label && $csv_columns) {
+          $context_data = [];
           foreach ($column_keys as $index => $column) {
             if ($column !== 'original' && $column !== 'csv_columns' && $column !== 'checked') {
               $lod = $form_state->getValue($column . '-' . $id, NULL);
               $context_data[$column]['lod'] = $lod;
-              $context_data[$column]['columns'] = $csv_columns;
-              $context_data['checked'] = $checked;
-              $this->AmiLoDService->setKeyValuePerAmiSet($label,
-                $context_data, $this->entity->id());
             }
           }
+          // This was wrongly called too many times. Only once per label needed
+          $context_data['checked'] = $checked;
+          $context_data[$column]['columns'] = $csv_columns;
+          $this->AmiLoDService->setKeyValuePerAmiSet(
+            $label,
+            $context_data, $this->entity->id()
+          );
         }
         else {
           $this->messenger()->addError(

--- a/src/Form/amiSetEntityReconcileForm.php
+++ b/src/Form/amiSetEntityReconcileForm.php
@@ -189,6 +189,7 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
             '#prefix' => '<div id="lod-options-wrapper">',
             '#suffix' => '</div>',
           ];
+
           $reconcile_mapping_settings = $form_state->getValue(['lod_options', 'mappings'], NULL) ?? ($data->reconcileconfig->mappings ?? NULL);
           $reconcile_mapping_settings = (array) $reconcile_mapping_settings;
           if ($reconcile_column_settings) {
@@ -257,7 +258,7 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
           'Re-process only adding new terms/LoD Authority Sources.'
         ),
         '#description' => $this->t(
-          'Check this to add to existing reconciliation new terms and LoD Authority Sources, e.g after replacing the Source CSV data.<br> Existing terms/LoD Authority Sources you already selected will not be affected.<br> This also means you can unselect previous configurated terms/LoD Authority Sources and previous settings will be preserved allowing you for example to select a single colum and run the process again adding to what is there'
+          'Check this to add to existing reconciliation new terms and LoD Authority Sources, e.g after replacing the Source CSV data.<br> Existing terms/LoD Authority Sources you already selected will not be affected.<br> This also means you can unselect previous configurated terms/LoD Authority Sources and previous settings will be preserved allowing you for example to select a single colum and run the process again adding to what is there.<em>WARNING:</em> only labels present in the current Source CSV will be preserved. Please backup your Processed CSV.'
         ),
         '#required' => FALSE,
         '#default_value' => !empty($update_existing) ? $update_existing : FALSE,
@@ -348,7 +349,7 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
             $data->reconcileconfig->mappings->{$lod_columns})
           );
         }
-        $data->reconcileconfig = $data->reconcileconfig;
+        $mappings = (array) $data->reconcileconfig->mappings ?? [];
       }
       else {
         //Non update operation
@@ -359,6 +360,7 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
         $data->reconcileconfig->mappings = $form_state->getValue(
           ['lod_options', 'mappings'], NULL
         );
+        $mappings = (array) $data->reconcileconfig->mappings ?? [];
       }
 
       $jsonvalue = json_encode($data, JSON_PRETTY_PRINT);
@@ -379,7 +381,7 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
     // Do the actual processing.
     if ($file && $file_lod && $data !== new \stdClass()) {
       $domain = $this->getRequest()->getSchemeAndHttpHost();
-      $mappings = $form_state->getValue(['lod_options','mappings']);
+
       $form_state->setRebuild(TRUE);
 
       $columns = array_keys($mappings) ?? [];

--- a/src/Form/amiSetEntityReconcileForm.php
+++ b/src/Form/amiSetEntityReconcileForm.php
@@ -97,8 +97,6 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    // Read Config first to get the Selected Bundles based on the Config
-    // type selected. Based on that we can set Moderation Options here
 
     $data = new \stdClass();
     foreach ($this->entity->get('set') as $item) {
@@ -164,11 +162,13 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
           $csv_file_reference[0]['target_id']
         );
         if ($file) {
+          $file_data_all = $this->AmiUtilityService->csv_read($file);
+          $column_keys = $file_data_all['headers'] ?? [];
 
           $reconcile_column_settings = $form_state->getValue(['mapping', 'lod_columns'], NULL) ?? ($data->reconcileconfig->columns ?? []);
           $reconcile_column_settings = (array) $reconcile_column_settings;
-          $file_data_all = $this->AmiUtilityService->csv_read($file);
-          $column_keys = $file_data_all['headers'] ?? [];
+          //@ TODO we should remove from settings columns not present in the Source Data.
+          // Forms state will do that automatically but i prefer that as a sanity check
           $form['mapping']['lod_columns'] = [
             '#type' => 'select',
             '#title' => $this->t('Select which columns you want to reconcile against LoD providers'),
@@ -189,32 +189,11 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
             '#prefix' => '<div id="lod-options-wrapper">',
             '#suffix' => '</div>',
           ];
-          $reconcile_mapping_settings = $form_state->getValue(['mapping', 'lod_columns'], NULL) ?? ($data->reconcileconfig->mappings ?? NULL);
+          $reconcile_mapping_settings = $form_state->getValue(['lod_options', 'mappings'], NULL) ?? ($data->reconcileconfig->mappings ?? NULL);
           $reconcile_mapping_settings = (array) $reconcile_mapping_settings;
           if ($reconcile_column_settings) {
-
             $source_options = $reconcile_column_settings;
-            $column_options = [
-              'loc;subjects;thing' => 'LoC subjects(LCSH)',
-              'loc;names;thing' => 'LoC Name Authority File (LCNAF)',
-              'loc;genreForms;thing' => 'LoC Genre/Form Terms (LCGFT)',
-              'loc;graphicMaterials;thing' => 'LoC Thesaurus of Graphic Materials (TGN)',
-              'loc;geographicAreas;thing' => 'LoC MARC List for Geographic Areas',
-              'loc;relators;thing' => 'LoC Relators Vocabulary (Roles)',
-              'loc;rdftype;CorporateName' => 'LoC MADS RDF by type: Corporate Name',
-              'loc;rdftype;PersonalName' => 'LoC MADS RDF by type: Personal Name',
-              'loc;rdftype;FamilyName' => 'LoC MADS RDF by type: Family Name',
-              'loc;rdftype;Topic' => 'LoC MADS RDF by type: Topic',
-              'loc;rdftype;GenreForm' =>  'LoC MADS RDF by type: Genre Form',
-              'loc;rdftype;Geographic' => 'LoC MADS RDF by type: Geographic',
-              'loc;rdftype;Temporal' =>  'LoC MADS RDF by type: Temporal',
-              'loc;rdftype;ExtraterrestrialArea' => 'LoC MADS RDF by type: Extraterrestrial Area',
-              'viaf;subjects;thing' => 'Viaf',
-              'getty;aat;fuzzy' => 'Getty aat Fuzzy',
-              'getty;aat;terms' => 'Getty aat Terms',
-              'getty;aat;exact' => 'Getty aat Exact Label Match',
-              'wikidata;subjects;thing' => 'Wikidata Q Items'
-            ];
+            $column_options = $this->AmiLoDService::AMI_FORM_EXPOSED_LOD_SOURCES;
             $form['lod_options']['#type'] = 'fieldset';
             $form['lod_options']['#tree'] = TRUE;
 
@@ -258,6 +237,7 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
       }
 
       $notprocessnow = $form_state->getValue('not_process_now', NULL);
+      $update_existing = $form_state->getValue('update_existing', NULL);
 
       $form['not_process_now'] = [
         '#type' => 'checkbox',
@@ -270,6 +250,20 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
         '#required' => FALSE,
         '#default_value' => !empty($notprocessnow) ? $notprocessnow : FALSE,
       ];
+
+      $form['update_existing'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t(
+          'Re-process only adding new terms/LoD Authority Sources.'
+        ),
+        '#description' => $this->t(
+          'Check this to add to existing reconciliation new terms and LoD Authority Sources, e.g after replacing the Source CSV data.<br> Existing terms/LoD Authority Sources you already selected will not be affected.<br> This also means you can unselect previous configurated terms/LoD Authority Sources and previous settings will be preserved allowing you for example to select a single colum and run the process again adding to what is there'
+        ),
+        '#required' => FALSE,
+        '#default_value' => !empty($update_existing) ? $update_existing : FALSE,
+      ];
+
+
     }
     $form = $form + parent::buildForm($form, $form_state);
     return $form;
@@ -320,19 +314,58 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
     }
 
     $data = new \stdClass();
+
+    // Is this a new reconciliation or one being appended to?
+    $update_existing = $form_state->getValue('update_existing', FALSE);
+
     foreach ($this->entity->get('set') as $item) {
       /** @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $item */
       $data = $item->provideDecoded(FALSE);
       // Set also the new config back
-      $data->reconcileconfig = new \stdClass();
-      $data->reconcileconfig->columns = $form_state->getValue(['mapping', 'lod_columns'], NULL);
-      $data->reconcileconfig->mappings = $form_state->getValue(['lod_options','mappings'], NULL);
+      $new_lod_columns = [];
+      $new_lod_mappings = [];
+      // Deal with merging existing config with new config. This won't
+      // remove old configs yet
+      if ($update_existing) {
+        $new_lod_columns = $form_state->getValue(
+          ['mapping', 'lod_columns'], []
+        );
+        $new_lod_mappings = $form_state->getValue(
+          ['lod_options', 'mappings'], []
+        );
+
+        foreach ($new_lod_columns as $lod_columns) {
+          $data->reconcileconfig->columns->{$lod_columns} = $lod_columns;
+        }
+        foreach ($new_lod_mappings as $lod_columns => $lod_mappings) {
+          // We use array_values to avoid an Object casting of reordered Arrays
+          $data->reconcileconfig->mappings->{$lod_columns}
+            = isset($data->reconcileconfig->mappings->{$lod_columns}) && is_array($data->reconcileconfig->mappings->{$lod_columns})
+            ? array_values(array_merge(
+              $data->reconcileconfig->mappings->{$lod_columns}, $lod_mappings
+            )) : array_values($lod_mappings);
+          $data->reconcileconfig->mappings->{$lod_columns} = array_values(array_unique(
+            $data->reconcileconfig->mappings->{$lod_columns})
+          );
+        }
+        $data->reconcileconfig = $data->reconcileconfig;
+      }
+      else {
+        //Non update operation
+        $data->reconcileconfig = new \stdClass();
+        $data->reconcileconfig->columns = $form_state->getValue(
+          ['mapping', 'lod_columns'], NULL
+        );
+        $data->reconcileconfig->mappings = $form_state->getValue(
+          ['lod_options', 'mappings'], NULL
+        );
+      }
+
       $jsonvalue = json_encode($data, JSON_PRETTY_PRINT);
       $this->entity->set('set', $jsonvalue);
       try {
         $this->entity->save();
-      }
-      catch (\Exception $exception) {
+      } catch (\Exception $exception) {
         $this->messenger()->addError(
           t(
             'Ami Set LoD Settings Failed to be persisted because of @message',
@@ -343,15 +376,12 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
         return;
       }
     }
+    // Do the actual processing.
     if ($file && $file_lod && $data !== new \stdClass()) {
       $domain = $this->getRequest()->getSchemeAndHttpHost();
       $mappings = $form_state->getValue(['lod_options','mappings']);
       $form_state->setRebuild(TRUE);
-      $output = [];
-      $output['table'] = [
-        '#type' => 'table',
-        '#caption' => t('Unique processed values for this column'),
-      ];
+
       $columns = array_keys($mappings) ?? [];
       $values_per_column = $this->AmiUtilityService->provideDifferentColumnValuesFromCSV($file,
         $columns);
@@ -378,8 +408,10 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
       // This will be used to fetch the right values when passing to the twig template
       // Could be read from the config but this is faster during process.
 
-      // Clears old values before processing new ones.
-      $this->AmiLoDService->cleanKeyValuesPerAmiSet($this->entity->id());
+      // Clears old values before processing new ones for new sets
+      if (!$update_existing) {
+        $this->AmiLoDService->cleanKeyValuesPerAmiSet($this->entity->id());
+      }
       $this->AmiLoDService->setKeyValueMappingsPerAmiSet($normalized_mapping, $this->entity->id());
 
 
@@ -434,6 +466,7 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
           'csv_columns' => $column_map_inverted[$label],
           'normalized_mappings' => $normalized_mapping,
           'lodconfig' => $lodconfig,
+          'update_existing' => $update_existing,
           'set_id' => $this->entity->id(),
           'csv' => $file_lod_id,
           'uid' => $this->currentUser()->id(),


### PR DESCRIPTION
See #93 

This pull adds new Update modes:

   - 'update':  "Normal Update. Will update a complete existing ADO's configured target field with new JSON Content."
   -  'replace' : "Replace Update. Will replace JSON keys found in an ADO's configured target field with new JSON content. Not provided ones will be kept"
   - 'append': "Append Update. Will append values to existing JSON keys in an ADO's configured target field. New ones will be added too."

Adds also safety switch that keeps existing Files always safe and "undeletable" and "unreplaceable" but still allows new files to be added if Update or Append are used. 

JSON patching logging is going to be disabled by default until #92 is defined.