### PR TITLE
ISSUE-107: fix out of memory when fetching Top objects with lots of children

### DIFF
--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -832,11 +832,15 @@ class AmiUtilityService {
    *   'data' will be rows and may/not be associative.
    *
    * @param string $uuid_key
+   *    The header key can has/should have the UUIDs of new/existing ADOs.
+   * @param boolean $auto_uuid
+   *    Defines if we are going to generate UUIDs when not valid/not present
+   *    Or leave the $uuid_key field as it is and let this fail/if later.
    *
    * @return int|string|null
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  public function csv_save(array $data, $uuid_key = 'node_uuid') {
+  public function csv_save(array $data, $uuid_key = 'node_uuid', $auto_uuid = TRUE) {
 
     //$temporary_directory = $this->fileSystem->getTempDirectory();
     // We should be allowing downloads for this from temp
@@ -959,7 +963,7 @@ class AmiUtilityService {
    * @return int|string|null
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  public function csv_append(array $data, File $file, $uuid_key = 'node_uuid', bool $append_header = TRUE, $escape_characters = TRUE) {
+  public function csv_append(array $data, File $file, $uuid_key = 'node_uuid', bool $append_header = TRUE, $escape_characters = TRUE, $auto_uuid = TRUE) {
 
     $wrapper = $this->streamWrapperManager->getViaUri($file->getFileUri());
     if (!$wrapper) {

--- a/src/Controller/AmiRowAutocompleteHandler.php
+++ b/src/Controller/AmiRowAutocompleteHandler.php
@@ -399,7 +399,7 @@ class AmiRowAutocompleteHandler extends ControllerBase {
             '#title' => !$file ? t('AMI Set has no CSV File'): t('AMI Set has no data for chosen row.'),
             'error' => [
               '#markup' => t('The AMI set is empty.'),
-            ]
+            ],
           ];
           $response->addCommand(new OpenOffCanvasDialogCommand(t('Preview'),
             $output, ['width' => '50%']));

--- a/src/Controller/AmiRowAutocompleteHandler.php
+++ b/src/Controller/AmiRowAutocompleteHandler.php
@@ -53,7 +53,6 @@ class AmiRowAutocompleteHandler extends ControllerBase {
     $this->currentUser = $current_user;
     $this->entityTypeManager = $entity_type_manager;
     $this->AmiUtilityService = $ami_utility;
-
   }
 
   /**
@@ -80,7 +79,6 @@ class AmiRowAutocompleteHandler extends ControllerBase {
     if (!$input) {
       return new JsonResponse($results);
     }
-
 
     if (!$ami_set_entity) {
       return new JsonResponse($results);
@@ -229,7 +227,6 @@ class AmiRowAutocompleteHandler extends ControllerBase {
             }
           }
 
-
           // Set initial context.
           $context = [
             'node' => NULL,
@@ -278,9 +275,10 @@ class AmiRowAutocompleteHandler extends ControllerBase {
           ];
           $output['json']['dataOriginal'] = [
             '#type' => 'codemirror',
-            '#title' => t('Original JSON of this ADO <b>{{ dataOriginal.keyname.lod_endpoint_type }}</b> :'),
+            '#title' => t('Original JSON of an ADO <b>{{ dataOriginal.keyname }}</b> :'),
+            '#description' => t('This will data structure will contain the original values (before modification) of an ADO only when updating. Sadly we can not at this time preview it during an AMI set preview'),
             '#rows' => 60,
-            '#value' => json_encode($context['dataOriginal'], JSON_PRETTY_PRINT),
+            '#value' => json_encode('{}', JSON_PRETTY_PRINT),
             '#codemirror' => [
               'lineNumbers' => FALSE,
               'toolbar' => FALSE,
@@ -400,7 +398,7 @@ class AmiRowAutocompleteHandler extends ControllerBase {
             '#open' => TRUE,
             '#title' => !$file ? t('AMI Set has no CSV File'): t('AMI Set has no data for chosen row.'),
             'error' => [
-              '#markup' => $message,
+              '#markup' => t('The AMI set is empty.'),
             ]
           ];
           $response->addCommand(new OpenOffCanvasDialogCommand(t('Preview'),

--- a/src/Controller/AmiRowAutocompleteHandler.php
+++ b/src/Controller/AmiRowAutocompleteHandler.php
@@ -276,7 +276,7 @@ class AmiRowAutocompleteHandler extends ControllerBase {
           $output['json']['dataOriginal'] = [
             '#type' => 'codemirror',
             '#title' => t('Original JSON of an ADO <b>{{ dataOriginal.keyname }}</b> :'),
-            '#description' => t('This will data structure will contain the original values (before modification) of an ADO only when updating. Sadly we can not at this time preview it during an AMI set preview'),
+            '#description' => t('This data structure will contain the original values (before modification) of an ADO only when updating. Sadly we can not at this time preview it during an AMI set preview.'),
             '#rows' => 60,
             '#value' => json_encode('{}', JSON_PRETTY_PRINT),
             '#codemirror' => [

--- a/src/Form/AmiMultiStepIngest.php
+++ b/src/Form/AmiMultiStepIngest.php
@@ -117,7 +117,7 @@ class AmiMultiStepIngest extends AmiMultiStepIngestBaseForm {
     // TO keep this discrete and easier to edit maybe move to it's own method?
     if ($this->step == 3) {
       // We should never reach this point if data is not enough. Submit handler
-      // will back to Step 2 if so.
+      // will go back to Step 2 if so.
       $data = $this->store->get('data') ?? [];
       $pluginconfig = $this->store->get('pluginconfig');
       $plugin_instance = $this->store->get('plugininstance');

--- a/src/Form/AmiMultiStepIngest.php
+++ b/src/Form/AmiMultiStepIngest.php
@@ -150,12 +150,14 @@ class AmiMultiStepIngest extends AmiMultiStepIngestBaseForm {
         '#description' => $this->t('Columns will be casted to ADO metadata (JSON) using a Twig template setup for JSON output'),
       ];
 
-      /* $element_conditional['webform'] =[
-         '#type' => 'select',
-         '#title' => $this->t('Webform'),
-         '#options' => $webform,
-         '#description' => $this->t('Columns are casted to ADO metadata (JSON) by passing/validating Data through an existing Webform'),
-       ];*/
+      /**
+       * $element_conditional['webform'] = [
+       *   '#type' => 'select',
+       *   '#title' => $this->t('Webform'),
+       *   '#options' => $webform,
+       *   '#description' => $this->t('Columns are casted to ADO metadata (JSON) by passing/validating Data through an existing Webform'),
+       * ];
+       */
 
       $form['ingestsetup']['globalmapping'] = [
         '#type' => 'select',

--- a/src/Form/AmiMultiStepIngest.php
+++ b/src/Form/AmiMultiStepIngest.php
@@ -291,7 +291,7 @@ class AmiMultiStepIngest extends AmiMultiStepIngestBaseForm {
     }
 
     if ($this->step == 4) {
-      $data = $this->store->get('data');
+      $data = $this->store->get('data') ?? [];
       $pluginconfig = $this->store->get('pluginconfig');
       $op = $pluginconfig['op'];
       $plugin_instance = $this->store->get('plugininstance');

--- a/src/Form/AmiMultiStepIngest.php
+++ b/src/Form/AmiMultiStepIngest.php
@@ -590,7 +590,8 @@ class AmiMultiStepIngest extends AmiMultiStepIngestBaseForm {
         if (!$plugin_instance->getPluginDefinition()['batch']) {
           // We now pass also if auto UUID was chosen or not.
           $fileid = $this->AmiUtilityService->csv_save($data, $uuid_key, $amisetdata->adomapping['autouuid'] ?? FALSE);
-        } else {
+        }
+        else {
           $fileid = $this->AmiUtilityService->csv_touch();
         }
         $batch = [];

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -857,7 +857,8 @@ class SolrImporter extends SpreadsheetImporter {
           // If deep traverse is enabled we should also mark collections here?
           // Call getData recursevely?
 
-        } catch (\Exception $exception) {
+        }
+        catch (\Exception $exception) {
           continue;
         }
       }

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -760,7 +760,7 @@ class SolrImporter extends SpreadsheetImporter {
         $escaped = '('. $escaped .')';
         $query->setQuery('*:*');
 
-        $query->createFilterQuery('collection_members')->setQuery('RELS_EXT_isMemberOfCollection_uri_s:'.$escaped .' OR RELS_EXT_isMemberOf_uri_s:'.$escaped );
+        $query->createFilterQuery('collection_members')->setQuery('RELS_EXT_isMemberOfCollection_uri_s:' . $escaped . ' OR RELS_EXT_isMemberOf_uri_s:' . $escaped);
         // PLEASE REMOVE Collection Objects that ARE ALSO part of a compound. WE DO NOT WANT THOSE
         $query->createFilterQuery('notconstituent')->setQuery('-RELS_EXT_isConstituentOf_uri_ms:[ * TO * ]');
         $query->addSort('PID', 'asc');

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -40,8 +40,8 @@ class SolrImporter extends SpreadsheetImporter {
     'info:fedora/islandora:bookCModel',
     'info:fedora/islandora:newspaperIssueCModel',
     'info:fedora/islandora:newspaperCModel',
+    'info:fedora/islandora:manuscriptCModel',
   ];
-
 
   const FILE_COLUMNS = [
     'documents',
@@ -250,7 +250,7 @@ class SolrImporter extends SpreadsheetImporter {
         '#default_value' => $rows,
       ],
     ];
-    /** 
+    /**
      * @TODO let's tell the user why it is not ready?
      * Also todo, move mappings already done between children/parents/children
      * That way previous decisions on any of each sides will stick on the other

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -482,7 +482,7 @@ class SolrImporter extends SpreadsheetImporter {
         $escaped = '('. $escaped .')';
 
         $query->setQuery('*:*');
-        $query->createFilterQuery('collection_members')->setQuery('RELS_EXT_isMemberOfCollection_uri_s:'.$escaped .' OR RELS_EXT_isMemberOf_uri_s:'.$escaped );
+        $query->createFilterQuery('collection_members')->setQuery('RELS_EXT_isMemberOfCollection_uri_s:' . $escaped . ' OR RELS_EXT_isMemberOf_uri_s:' . $escaped);
         // PLEASE REMOVE Collection Objects that ARE ALSO part of a compound. WE DO NOT WANT THOSE
         $query->createFilterQuery('notconstituent')->setQuery('-RELS_EXT_isConstituentOf_uri_ms:[ * TO * ]');
         /*

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -642,7 +642,8 @@ class SolrImporter extends SpreadsheetImporter {
       if (((count(array_intersect_key($form_state->getValue(['pluginconfig', 'solarium_mapping','cmodel_children'], []), $cmodel_children)) == count($cmodel_children))
           && count($cmodel_children) >= 1) || $form_state->getValue(['pluginconfig', 'solarium_mapping', 'collapse']) == TRUE) {
         $form_state->setValue(['pluginconfig', 'ready'], TRUE);
-      } else {
+      }
+      else {
         $form_state->setValue(['pluginconfig', 'ready'], FALSE);
       }
 

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -996,7 +996,9 @@ class SolrImporter extends SpreadsheetImporter {
     ]);
 
     $resultset = $client->select($query);
-    if ($resultset->getNumFound() == 0) { return []; }
+    if ($resultset->getNumFound() == 0) {
+      return [];
+    }
 
     $resultset_iterator = $resultset->getIterator();
     // Empty value? just return

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -1244,7 +1244,7 @@ class SolrImporter extends SpreadsheetImporter {
       $data = $plugin_instance->getData($config, $nextoffset,
         $next_increment);
 
-      if (isset($data['nextforcedoffset']) && $data['nextforcedoffset'] !== NULL ) {
+      if (isset($data['nextforcedoffset']) && $data['nextforcedoffset'] !== NULL) {
         $context['sandbox']['nextforcedoffset'] = $data['nextforcedoffset'];
       }
       else {

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -160,6 +160,7 @@ class SolrImporter extends SpreadsheetImporter {
         '#description' => $this->t('If checked AMI will try to fetch Collections of Collections. Even if disabled, by default it will always get other parent/children hierarchies.'),
         '#default_value' => $form_state->getValue(array_merge($parents,
           ['solarium_config', 'deep'])),
+        '#disabled' => TRUE,
       ],
       'host' => [
         '#type' => 'textfield',
@@ -937,9 +938,6 @@ class SolrImporter extends SpreadsheetImporter {
         }
       }
 
-      // Clean empty headers
-
-
       $tabdata = [
         'headers' => array_keys($headers),
         'data' => $table,
@@ -951,7 +949,7 @@ class SolrImporter extends SpreadsheetImporter {
     }
     else {
       $this->messenger()->addMessage(
-        t('Your Solr Config did not work out. Sorry'),
+        t('Your Solr Config did not work out. Sorry. Check your settings or if your remote server is having issues.'),
         MessengerInterface::TYPE_ERROR
       );
     }

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -1216,11 +1216,13 @@ class SolrImporter extends SpreadsheetImporter {
         );
       }
       else {
+        $progress = $context['sandbox']['progress'] + $next_increment;
+        $progress = ($progress >= $rows) ? $rows : $progress;
         $title = t(
           'Fetching %progress of <b>%count</b> top Objects with <b>%total</b> total rows retrieved so far.',
           [
             '%count'    => $rows,
-            '%progress' => $context['sandbox']['progress'] + $next_increment,
+            '%progress' => $progress,
             '%total'    => $context['sandbox']['totalfound']
           ]
         );

--- a/src/Plugin/ImporterAdapter/SolrImporter.php
+++ b/src/Plugin/ImporterAdapter/SolrImporter.php
@@ -250,9 +250,11 @@ class SolrImporter extends SpreadsheetImporter {
         '#default_value' => $rows,
       ],
     ];
-    /* @TODO let's tell the user why it is not ready? */
-    /* Also todo, move mappings already done between children/parents/children */
-    /* That way previous decisions on any of each sides will stick on the other */
+    /** 
+     * @TODO let's tell the user why it is not ready?
+     * Also todo, move mappings already done between children/parents/children
+     * That way previous decisions on any of each sides will stick on the other
+     */
     $cmodels = $form_state->get('facet_cmodel') ?? $form_state->getValue(array_merge($parents,
         ['solarium_mapping', 'cmodel_mapping']), []);
     $cmodels_children = $form_state->get('facet_cmodel_children') ?? $form_state->getValue(array_merge($parents,


### PR DESCRIPTION
# What?

See #107. 
- Adds adaptive Range/offset based on what was the last number of Top objects v/s Children Rations
- Copies CMODEL mapping between Children/Top objects during setup
- Validates UUID Mapping v/s Node to Node Mapping (to avoid those being mixed up)
- Multiple cleanups, fixes Automatic UUID for Plugins that run via Batch (e.g Solr)

@karomabiles and @alliomeria even if this is safer, I feel it just became a bit slower so will need you both to check with me during our call the same collection being harvested via your current systems v/s with this patch. I can do a pre-test just to be sure of course and make you loose less time

