### PR TITLE
ISSUE-113: Preserve UUID when reusing a file

### DIFF
--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -689,19 +689,21 @@ class AmiUtilityService {
         [
           'uri' => $localpath,
           'uid' => $this->currentUser->id(),
-          'status' => FILE_STATUS_PERMANENT,
+          'status' => FileInterface::STATUS_PERMANENT,
         ]
       );
       // If we are replacing an existing file re-use its database record.
       // @todo Do not create a new entity in order to update it. See
       //   https://www.drupal.org/node/2241865.
       // Check if File with same URI already exists.
+      // @TODO: Should we check for AMI also if the current user can update the file?
       $existing_files = \Drupal::entityTypeManager()
         ->getStorage('file')
         ->loadByProperties(['uri' => $localpath]);
       if (count($existing_files)) {
         $existing = reset($existing_files);
         $file->fid = $existing->id();
+        $file->uuid = $existing->uuid();
         $file->setOriginalId($existing->id());
         $file->setFilename($existing->getFilename());
       }


### PR DESCRIPTION
See #113 

We try hard to reuse files and this now makes sure UUID is reused too. This of course opens the question of, and even if AMI users are power user,  should be allow file reuse without checking access? Or said differently, we can reuse, but maybe not change the owner? Still this fixes the problem and TBH this only will trigger if the source/destination are the same, means files coming from S3.