### PR TITLE
ISSUE-115:Replace ::seek() with multiple ::next() to work around bug in PHP8/7/6/5

### DIFF
--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -1071,7 +1071,12 @@ class AmiUtilityService {
 
     if ($offset > 0 && !$always_include_header) {
       // If header needs to be included then we offset later on
-      $spl->seek($offset);
+      // PHP 8.0.16 IS STILL BUGGY with SEEK.
+      //$spl->seek($offset) does not work here.
+      for ($i = 0; $i < $offset; $i++) {
+        $spl->next();
+      }
+
     }
     $data = [];
     $seek_to_offset = ($offset > 0 && $always_include_header);
@@ -1083,7 +1088,11 @@ class AmiUtilityService {
         $data[] = $spl->fgetcsv();
       }
       if ($seek_to_offset) {
-        $spl->seek($offset);
+        for ($i = 0; $i < $offset; $i++) {
+          $spl->next();
+        }
+        // PHP 8.0.16 IS STILL BUGGY with SEEK.
+        //$spl->seek($offset); doe snot work here
         // So we do not process this again.
         $seek_to_offset = FALSE;
       }


### PR DESCRIPTION
See #115 

This fixes it. @alliomeria did some checks. I did some checks. All checks out. 

Eventually we might use a CSV library (a good colleague suggested this) but for now Vanilla CSV works.