### PR TITLE
ISSUE-8: Add CSV reporting + Skip on missing file(s)

### DIFF
--- a/ami.install
+++ b/ami.install
@@ -114,5 +114,31 @@ function ami_update_8904() {
   \Drupal::entityDefinitionUpdateManager()->updateFieldStorageDefinition($field_storage_definition);
 }
 
+/**
+ * Update 8905 - Add Report CSV file Field for AMI Set entity.
+ */
+function ami_update_8905() {
+  $validators = [
+      'file_validate_extensions' => ['csv'],
+      'file_validate_size' => [Environment::getUploadMaxSize()],
+    ];
+
+  $storage_definition = BaseFieldDefinition::create('file')
+       ->setLabel(t('AMI Process Reports'))
+       ->setDescription(t('Processed set report in CSV format'))
+       ->setSetting('file_extensions', 'csv')
+       ->setSetting('upload_validators', $validators)
+       ->setSetting('uri_scheme', 'private')
+       ->setSetting('file_directory', '/ami/reports')
+       ->setRequired(FALSE)
+       ->setDisplayOptions('view', [
+         'label' => 'above',
+         'type' => 'file',
+         'weight' => -2,
+       ])
+       ->setDisplayConfigurable('view', TRUE)
+       ->setDisplayConfigurable('form', TRUE);
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('report_file', 'ami_set_entity', 'ami', $storage_definition);
+}
 
 

--- a/ami.install
+++ b/ami.install
@@ -45,9 +45,9 @@ function ami_update_8901() {
  */
 function ami_update_8902() {
   $validators = [
-      'file_validate_extensions' => ['zip'],
-      'file_validate_size' => [Environment::getUploadMaxSize()],
-    ];
+    'file_validate_extensions' => ['zip'],
+    'file_validate_size' => [Environment::getUploadMaxSize()],
+  ];
   $storage_definition = BaseFieldDefinition::create('file')
     ->setLabel(new TranslatableMarkup('Attached ZIP file'))
     ->setDescription(new TranslatableMarkup('A Zip file containing accompanying Files for the Source Data'))
@@ -64,8 +64,8 @@ function ami_update_8902() {
     ->setDisplayOptions('form', [
       'type' => 'file',
       'description' => [
-      'theme' => 'file_upload_help',
-      'description' => new TranslatableMarkup('Source Files for this Set')
+        'theme' => 'file_upload_help',
+        'description' => new TranslatableMarkup('Source Files for this Set')
       ],
       'settings' => [
         'upload_validators' => $validators,
@@ -83,25 +83,25 @@ function ami_update_8902() {
  */
 function ami_update_8903() {
   \Drupal::entityDefinitionUpdateManager()->installEntityType(new ConfigEntityType([
-     'id' => 'importeradapter',
-     'label' => new TranslatableMarkup('AMI Importer Adapter'),
-     'config_prefix' => 'importeradapter',
-     'admin_permission' => 'administer site configuration',
-     'entity_keys' => [
-       'id' => 'id',
-       'label' => 'label',
-       'uuid' => 'uuid',
-     ],
-     'config_export' => [
-        "id",
-        "label",
-        "plugin",
-        "update_existing",
-        "target_entity_types",
-        "active",
-        "plugin_configuration"
-     ],
-   ]));
+    'id' => 'importeradapter',
+    'label' => new TranslatableMarkup('AMI Importer Adapter'),
+    'config_prefix' => 'importeradapter',
+    'admin_permission' => 'administer site configuration',
+    'entity_keys' => [
+      'id' => 'id',
+      'label' => 'label',
+      'uuid' => 'uuid',
+    ],
+    'config_export' => [
+      "id",
+      "label",
+      "plugin",
+      "update_existing",
+      "target_entity_types",
+      "active",
+      "plugin_configuration"
+    ],
+  ]));
 }
 
 /**
@@ -119,26 +119,44 @@ function ami_update_8904() {
  */
 function ami_update_8905() {
   $validators = [
-      'file_validate_extensions' => ['csv'],
-      'file_validate_size' => [Environment::getUploadMaxSize()],
-    ];
+    'file_validate_extensions' => ['csv'],
+    'file_validate_size' => [Environment::getUploadMaxSize()],
+  ];
 
   $storage_definition = BaseFieldDefinition::create('file')
-       ->setLabel(t('AMI Process Reports'))
-       ->setDescription(t('Processed set report in CSV format'))
-       ->setSetting('file_extensions', 'csv')
-       ->setSetting('upload_validators', $validators)
-       ->setSetting('uri_scheme', 'private')
-       ->setSetting('file_directory', '/ami/reports')
-       ->setRequired(FALSE)
-       ->setDisplayOptions('view', [
-         'label' => 'above',
-         'type' => 'file',
-         'weight' => -2,
-       ])
-       ->setDisplayConfigurable('view', TRUE)
-       ->setDisplayConfigurable('form', TRUE);
+    ->setLabel(t('AMI Process Reports'))
+    ->setDescription(t('Processed set report in CSV format'))
+    ->setSetting('file_extensions', 'csv')
+    ->setSetting('upload_validators', $validators)
+    ->setSetting('uri_scheme', 'private')
+    ->setSetting('file_directory', '/ami/reports')
+    ->setRequired(FALSE)
+    ->setDisplayOptions('view', [
+      'label' => 'above',
+      'type' => 'file',
+      'weight' => -2,
+    ])
+    ->setDisplayConfigurable('view', TRUE)
+    ->setDisplayConfigurable('form', TRUE);
   \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('report_file', 'ami_set_entity', 'ami', $storage_definition);
+  $field_storage_definition_status = \Drupal::entityDefinitionUpdateManager()->getFieldStorageDefinition('status', 'ami_set_entity');
+  $field_storage_definition_status->setLabel(t("This Set's last known status"));
+  $field_storage_definition_status->setSetting('allowed_values', \Drupal\ami\Entity\amiSetEntity::STATUS);
+  $field_storage_definition_status->setSetting('default_value', 'READY');
+  \Drupal::entityDefinitionUpdateManager()->updateFieldStorageDefinition($field_storage_definition_status);
+
+  // Update all AMI sets already with 'ready' use the new uppercase default
+  $entities_nids = \Drupal::entityQuery('ami_set_entity')
+    ->condition('status', 'ready')
+    ->execute();
+
+  // Load all the articles.
+  $entities = \Drupal::entityTypeManager()->getStorage('ami_set_entity')->loadMultiple($entities_nids);
+  foreach ($entities as $entity) {
+    $entity->setStatus(\Drupal\ami\Entity\amiSetEntity::STATUS_READY);
+    $entity->save();
+  }
+
 }
 
 

--- a/ami.links.task.yml
+++ b/ami.links.task.yml
@@ -51,8 +51,8 @@ entity.ami_set_entity.reconcileedit_form:
   title: Edit Reconciled LoD
   weight: 14
 
-entity.ami_set_entity.reports_form:
-  route_name: entity.ami_set_entity.reports_form
+entity.ami_set_entity.report_form:
+  route_name: entity.ami_set_entity.report_form
   base_route: entity.ami_set_entity.canonical
   title: Reports
   weight: 15

--- a/ami.links.task.yml
+++ b/ami.links.task.yml
@@ -50,3 +50,9 @@ entity.ami_set_entity.reconcileedit_form:
   base_route: entity.ami_set_entity.canonical
   title: Edit Reconciled LoD
   weight: 14
+
+entity.ami_set_entity.reports_form:
+  route_name: entity.ami_set_entity.reports_form
+  base_route: entity.ami_set_entity.canonical
+  title: Reports
+  weight: 15

--- a/ami.module
+++ b/ami.module
@@ -151,6 +151,15 @@ function ami_entity_delete(Drupal\Core\Entity\EntityInterface $entity) {
     AmiUtilityService::invalidateAmiSetDeleteAdosAccessCache($entity);
     // Remove any AMI LoD Key Values.
     \Drupal::service('ami.lod')->cleanKeyValuesPerAmiSet($entity->id());
+    // Remove any left over logs
+    try {
+      $log_location = "private://ami/logs/set{$entity->id()}.log";
+      $filePath = \Drupal::service('file_system')->realpath($log_location);
+      \Drupal::service('file_system')->delete($filePath);
+    }
+    catch (\Exception $exception) {
+      watchdog_exception('ami', $exception);
+    }
   }
 }
 

--- a/ami.permissions.yml
+++ b/ami.permissions.yml
@@ -38,4 +38,4 @@ deleteados amiset entity:
 deleteados own amiset entity:
   title: 'Delete ADOs generated through own AMI Set Entities'
 override file destination ami entity:
-  title: 'Override default persistent file destination and naming for Files ingested via AMI Set Entities'
+  title: 'Override default persistent file destination and naming for Files ingested via AMI Set Entities. This permission breaks how Archipelago conceives file preservation as a core concern so out of the box will not trigger any chance without enabled a Drupal settings.php global option. See Documentation for this'

--- a/ami.permissions.yml
+++ b/ami.permissions.yml
@@ -37,3 +37,5 @@ deleteados amiset entity:
   restrict access: TRUE
 deleteados own amiset entity:
   title: 'Delete ADOs generated through own AMI Set Entities'
+override file destination ami entity:
+  title: 'Override default persistent file destination and naming for Files ingested via AMI Set Entities'

--- a/ami.routing.yml
+++ b/ami.routing.yml
@@ -102,6 +102,14 @@ entity.ami_set_entity.reconcileedit_form:
   requirements:
     _entity_access: 'ami_set_entity.process'
 
+entity.ami_set_entity.reports_form:
+  path: '/amiset/{ami_set_entity}/report'
+  defaults:
+    _entity_form: ami_set_entity.report
+    _title: 'Reports'
+  requirements:
+    _entity_access: 'ami_set_entity.process'
+
 ami.rowsbylabel.autocomplete:
   path: '/admin/amiset/autocomplete/{ami_set_entity}/rowsbylabel'
   options:

--- a/ami.routing.yml
+++ b/ami.routing.yml
@@ -35,7 +35,7 @@ entity.ami_set_entity.collection:
   path: '/amiset/list'
   defaults:
     _entity_list: 'ami_set_entity'
-    _title: 'AMI Set Display List'
+    _title: 'AMI Set List'
   requirements:
     _permission: 'administer amiset entity'
 
@@ -102,7 +102,7 @@ entity.ami_set_entity.reconcileedit_form:
   requirements:
     _entity_access: 'ami_set_entity.process'
 
-entity.ami_set_entity.reports_form:
+entity.ami_set_entity.report_form:
   path: '/amiset/{ami_set_entity}/report'
   defaults:
     _entity_form: ami_set_entity.report

--- a/ami.services.yml
+++ b/ami.services.yml
@@ -32,3 +32,8 @@ services:
     arguments: [ '@views_bulk_operations.data' ,'@current_user', '@tempstore.private' ]
     tags:
       - { name: event_subscriber }
+  ami.breadcrumb.amiset:
+    class: Drupal\ami\Breadcrumb\AmiSetBreadcrumbBuilder
+    #arguments: [ '@entity_type.manager', '@config.factory', '@forum_manager', '@string_translation' ]
+    tags:
+      - { name: breadcrumb_builder, priority: 1001 }

--- a/ami.services.yml
+++ b/ami.services.yml
@@ -22,6 +22,11 @@ services:
     tags:
       - { name: event_subscriber }
     arguments: [ '@string_translation', '@messenger', '@logger.factory', '@current_user', '@ami.utility', '@entity_type.manager', '@ami.lod']
+  ami.strawberryfield_presaveprocessjson_subscriber:
+    class: Drupal\ami\EventSubscriber\AmiStrawberryfieldEventPresaveSubscriberJsonTransform
+    tags:
+      - { name: event_subscriber }
+    arguments: [ '@string_translation', '@messenger', '@logger.factory', '@current_user', '@ami.utility', '@entity_type.manager', '@request_stack', '@renderer', '@config.factory']
   ami.facet_batch_view_data_provider:
     class: Drupal\ami\EventSubscriber\AmiFacetsViewsBulkOperationsEventSubscriber
     arguments: [ '@views_bulk_operations.data' ,'@current_user', '@tempstore.private' ]

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "phpoffice/phpspreadsheet": "^1.15.0",
         "maennchen/zipstream-php": "^1.2 || ^2.1",
         "drupal/google_api_client": "^3.0 || ^4.0",
-        "ramsey/uuid": "^4.1"
+        "ramsey/uuid": "^4.1",
+        "monolog/monolog": "^2.8"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -2131,7 +2131,6 @@ class AmiUtilityService {
       }
     }
 
-
     $metadatadisplay_entity = $this->entityTypeManager->getStorage('metadatadisplay_entity')
       ->load($metadatadisplay_id);
     if ($metadatadisplay_entity) {
@@ -2322,7 +2321,8 @@ class AmiUtilityService {
   public function getDifferentValuesfromColumnSplit(array $data, int $key, array $delimiters = ['|@|', ';'] ): array {
     $unique = [];
     $all = array_column($data['data'], $key);
-    $all_notJson = array_filter($all,  array($this, 'isNotJson'));
+    $all_isstring= array_filter($all, 'is_string');
+    $all_notJson = array_filter($all_isstring,  array($this, 'isNotJson'));
     $all_entries = [];
     // The difficulty. In case of multiple delimiters we need to see which one
     // works/works better. But if none, assume it may be also right since a single

--- a/src/Breadcrumb/AmiSetBreadcrumbBuilder.php
+++ b/src/Breadcrumb/AmiSetBreadcrumbBuilder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\ami\Breadcrumb;
+
+use Drupal\ami\amiSetEntityInterface;
+use Drupal\ami\Entity\amiSetEntity;
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Provides a breadcrumb for AMI Sets
+ */
+class AmiSetBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+
+  use StringTranslationTrait;
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    $amiset = $route_match->getParameter('ami_set_entity');
+    return $amiset instanceof amiSetEntityInterface;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    $breadcrumb = new Breadcrumb();
+    $breadcrumb->addCacheContexts(['route']);
+    $amiset = $route_match->getParameter('ami_set_entity');
+    $links[] = Link::createFromRoute($this->t('Home'), '<front>');
+
+    $links[] = Link::createFromRoute($this->t('Ami Set List'), 'entity.ami_set_entity.collection');
+    if ($amiset instanceof amiSetEntityInterface) {
+    $links[] = Link::createFromRoute($amiset->label(), 'entity.ami_set_entity.canonical', ['ami_set_entity' =>$amiset->id()]);
+    }
+    return $breadcrumb->setLinks($links);
+  }
+
+}

--- a/src/Entity/Controller/amiSetEntityListBuilder.php
+++ b/src/Entity/Controller/amiSetEntityListBuilder.php
@@ -59,7 +59,7 @@ class amiSetEntityListBuilder extends EntityListBuilder {
     $row['id'] = $entity->id();
     $row['name'] = $entity->toLink();
     $row['last update'] = \Drupal::service('date.formatter')->format($entity->changed->value, 'custom', 'd/m/Y');
-    $row['status'] = $entity->getStatus()->getValue();
+    $row['status'] = !empty($entity->getStatus()->getValue()) ? $entity->getStatus()->first()->getValue()['value'] : 'Undefined';
     return $row + parent::buildRow($entity);
   }
 
@@ -73,7 +73,7 @@ class amiSetEntityListBuilder extends EntityListBuilder {
       ];
 
       // If applicable to the AMI Set, add the delete processed ADOs operation.
-      if(AmiUtilityService::checkAmiSetDeleteAdosAccess($entity)) {
+      if (AmiUtilityService::checkAmiSetDeleteAdosAccess($entity)) {
         $operations['delete_processed'] = [
           'title' => $this->t('Delete Processed ADOs'),
           'weight' => 12,

--- a/src/Entity/Controller/amiSetEntityListBuilder.php
+++ b/src/Entity/Controller/amiSetEntityListBuilder.php
@@ -61,7 +61,7 @@ class amiSetEntityListBuilder extends EntityListBuilder {
     $row['name'] = $entity->toLink();
     $row['last update'] = \Drupal::service('date.formatter')->format($entity->changed->value, 'custom', 'd/m/Y');
     $status_code = !empty($entity->getStatus()->first()->getValue()) ? $entity->getStatus()->first()->getValue()['value'] : amiSetEntity::STATUS_NOT_READY;
-    $row['status'] = amiSetEntity::STATUS[$status_code];
+    $row['status'] = amiSetEntity::STATUS[strtoupper($status_code)] ?? amiSetEntity::STATUS[amiSetEntity::STATUS_NOT_READY];
     return $row + parent::buildRow($entity);
   }
 
@@ -73,7 +73,13 @@ class amiSetEntityListBuilder extends EntityListBuilder {
         'weight' => 11,
         'url' => $this->ensureDestination($entity->toUrl('process-form')),
       ];
-
+      if ($entity->access('update') && $entity->hasLinkTemplate('report-form')) {
+        $operations['reports'] = [
+          'title'  => $this->t('Report'),
+          'weight' => 11,
+          'url'    => $this->ensureDestination($entity->toUrl('report-form')),
+        ];
+      }
       // If applicable to the AMI Set, add the delete processed ADOs operation.
       if (AmiUtilityService::checkAmiSetDeleteAdosAccess($entity)) {
         $operations['delete_processed'] = [
@@ -82,7 +88,6 @@ class amiSetEntityListBuilder extends EntityListBuilder {
           'url' => $this->ensureDestination($entity->toUrl('delete-process-form')),
         ];
       }
-
     }
     return $operations;
   }

--- a/src/Entity/Controller/amiSetEntityListBuilder.php
+++ b/src/Entity/Controller/amiSetEntityListBuilder.php
@@ -2,6 +2,7 @@
 namespace Drupal\ami\Entity\Controller;
 
 use Drupal\ami\amiSetEntityInterface;
+use Drupal\ami\Entity\amiSetEntity;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
 use Drupal\ami\AmiUtilityService;
@@ -59,7 +60,8 @@ class amiSetEntityListBuilder extends EntityListBuilder {
     $row['id'] = $entity->id();
     $row['name'] = $entity->toLink();
     $row['last update'] = \Drupal::service('date.formatter')->format($entity->changed->value, 'custom', 'd/m/Y');
-    $row['status'] = !empty($entity->getStatus()->first()->getValue()) ? $entity->getStatus()->first()->getValue()['value'] : 'Undefined';
+    $status_code = !empty($entity->getStatus()->first()->getValue()) ? $entity->getStatus()->first()->getValue()['value'] : amiSetEntity::STATUS_NOT_READY;
+    $row['status'] = amiSetEntity::STATUS[$status_code];
     return $row + parent::buildRow($entity);
   }
 

--- a/src/Entity/Controller/amiSetEntityListBuilder.php
+++ b/src/Entity/Controller/amiSetEntityListBuilder.php
@@ -59,7 +59,7 @@ class amiSetEntityListBuilder extends EntityListBuilder {
     $row['id'] = $entity->id();
     $row['name'] = $entity->toLink();
     $row['last update'] = \Drupal::service('date.formatter')->format($entity->changed->value, 'custom', 'd/m/Y');
-    $row['status'] = !empty($entity->getStatus()->getValue()) ? $entity->getStatus()->first()->getValue()['value'] : 'Undefined';
+    $row['status'] = !empty($entity->getStatus()->first()->getValue()) ? $entity->getStatus()->first()->getValue()['value'] : 'Undefined';
     return $row + parent::buildRow($entity);
   }
 

--- a/src/Entity/amiSetEntity.php
+++ b/src/Entity/amiSetEntity.php
@@ -141,6 +141,29 @@ class amiSetEntity extends ContentEntityBase implements amiSetEntityInterface {
   // Implements methods defined by EntityChangedInterface.
   use EntityChangedTrait;
 
+
+  public const STATUS_READY = 'READY';
+  public const STATUS_NOT_READY = 'NOT_READY';
+  public const STATUS_PROCESSING = 'PROCESSING';
+  public const STATUS_PROCESSED = 'PROCESSED';
+  public const STATUS_ENQUEUED = 'ENQUEUED';
+  public const STATUS_PROCESSING_WITH_ERRORS = 'PROCESSING_WITH_ERRORS';
+  public const STATUS_PROCESSED_WITH_ERRORS = 'PROCESSED_WITH_ERRORS';
+  public const STATUS_FAILED = 'FAILED';
+  public const STATUS_ENTITIES_DELETED = 'ENTITIES_DELETED';
+
+  public const STATUS = [
+    amiSetEntity::STATUS_READY => 'Ready to process',
+    amiSetEntity::STATUS_NOT_READY  => 'Not ready to process',
+    amiSetEntity::STATUS_PROCESSING => 'Sent to processing',
+    amiSetEntity::STATUS_PROCESSED => 'Processed',
+    amiSetEntity::STATUS_ENQUEUED => 'Enqueued',
+    amiSetEntity::STATUS_PROCESSING_WITH_ERRORS => 'Processing with some errors',
+    amiSetEntity::STATUS_PROCESSED_WITH_ERRORS => 'Processed with errors',
+    amiSetEntity::STATUS_FAILED => 'Failed',
+    amiSetEntity::STATUS_ENTITIES_DELETED => 'ADOs Deleted',
+  ];
+
   /**
    * {@inheritdoc}
    *
@@ -318,18 +341,13 @@ class amiSetEntity extends ContentEntityBase implements amiSetEntityInterface {
       ->setDescription(t('The time that the Ami Set was last edited.'));
 
     $fields['status'] = BaseFieldDefinition::create('list_string')
-      ->setLabel(t('This Set last known status'))
+      ->setLabel(t("This Set's last known status"))
       ->setDescription(t('Current Status of this Set'))
       ->setSettings([
-        'default_value' => 'ready',
+        'default_value' => 'READY',
         'max_length' => 64,
         'cardinality' => 1,
-        'allowed_values' => [
-          'ready' => 'ready',
-          'not ready' => 'notready',
-          'processed' => 'processed',
-          'enqueued' => 'enqueued',
-        ],
+        'allowed_values' => static::STATUS,
       ])
       ->setRequired(TRUE)
       ->setDisplayOptions('view', [

--- a/src/Entity/amiSetEntity.php
+++ b/src/Entity/amiSetEntity.php
@@ -412,6 +412,22 @@ class amiSetEntity extends ContentEntityBase implements amiSetEntityInterface {
       ])
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);
+
+    $fields['report_file'] = BaseFieldDefinition::create('file')
+      ->setLabel(t('AMI Process Reports'))
+      ->setDescription(t('Processed set reports in CSV format'))
+      ->setSetting('file_extensions', 'csv')
+      ->setSetting('upload_validators', $validators)
+      ->setSetting('uri_scheme', 'private')
+      ->setSetting('file_directory', '/ami/reports')
+      ->setRequired(FALSE)
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'file',
+        'weight' => -2,
+      ])
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE);
     return $fields;
   }
 }

--- a/src/Entity/amiSetEntity.php
+++ b/src/Entity/amiSetEntity.php
@@ -106,7 +106,7 @@ use Drupal\Component\Utility\Environment;
  *     "reconcile-form" = "/amiset/{ami_set_entity}/reconcile",
  *     "edit-reconcile-form" = "/amiset/{ami_set_entity}/editreconcile",
  *     "delete-form" = "/amiset/{ami_set_entity}/delete",
- *     "report" = "/amiset/{ami_set_entity}/report",
+ *     "report-form" = "/amiset/{ami_set_entity}/report",
  *     "collection" = "/amiset/list"
  *   },
  *   field_ui_base_route = "ami.amisetentity_settings",

--- a/src/Entity/amiSetEntity.php
+++ b/src/Entity/amiSetEntity.php
@@ -84,7 +84,8 @@ use Drupal\Component\Utility\Environment;
  *       "process" = "Drupal\ami\Form\amiSetEntityProcessForm",
  *       "deleteprocessed" = "Drupal\ami\Form\amiSetEntityDeleteProcessedForm",
  *       "reconcile" = "Drupal\ami\Form\amiSetEntityReconcileForm",
- *       "editreconcile" = "Drupal\ami\Form\amiSetEntityReconcileCleanUpForm"
+ *       "editreconcile" = "Drupal\ami\Form\amiSetEntityReconcileCleanUpForm",
+ *       "report" = "Drupal\ami\Form\amiSetEntityReportForm"
  *     },
  *     "access" = "Drupal\ami\Entity\Controller\amiSetEntityAccessControlHandler",
  *   },
@@ -105,6 +106,7 @@ use Drupal\Component\Utility\Environment;
  *     "reconcile-form" = "/amiset/{ami_set_entity}/reconcile",
  *     "edit-reconcile-form" = "/amiset/{ami_set_entity}/editreconcile",
  *     "delete-form" = "/amiset/{ami_set_entity}/delete",
+ *     "report" = "/amiset/{ami_set_entity}/report",
  *     "collection" = "/amiset/list"
  *   },
  *   field_ui_base_route = "ami.amisetentity_settings",

--- a/src/EventSubscriber/AmiStrawberryfieldEventPresaveSubscriberJsonTransform.php
+++ b/src/EventSubscriber/AmiStrawberryfieldEventPresaveSubscriberJsonTransform.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace Drupal\ami\EventSubscriber;
+
+use Drupal\ami\AmiUtilityService;
+use Drupal\Component\Uuid\Uuid;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Render\RenderContext;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventPresaveSubscriber;
+
+/**
+ * Event subscriber for SBF bearing entity presave event.
+ */
+class AmiStrawberryfieldEventPresaveSubscriberJsonTransform extends StrawberryfieldEventPresaveSubscriber {
+
+  use StringTranslationTrait;
+
+  /**
+   * @var int
+   *
+   *  This needs to run before any other Subscriber since it might affect the
+   *  The complete output.
+   */
+  protected static $priority = -1200;
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
+  /**
+   * The logger factory.
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
+   * @var \Drupal\ami\AmiUtilityService
+   */
+  protected $AmiUtilityService;
+
+  /**
+   * The entity manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The Drupal Renderer.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * The configuration factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+
+  /**
+   * AmiStrawberryfieldEventPresaveSubscriberJsonTransform constructor.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   * @param \Drupal\Core\Messenger\MessengerInterface           $messenger
+   * @param \Drupal\Core\Session\AccountInterface               $account
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface   $logger_factory
+   * @param \Drupal\ami\AmiUtilityService                       $ami_utility
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface      $entity_type_manager
+   * @param \Symfony\Component\HttpFoundation\RequestStack      $request_stack
+   * @param \Drupal\Core\Render\RendererInterface               $renderer
+   * @param \Drupal\Core\Config\ConfigFactoryInterface          $config_factory
+   */
+  public function __construct(
+    TranslationInterface $string_translation,
+    MessengerInterface $messenger,
+    AccountInterface $account,
+    LoggerChannelFactoryInterface $logger_factory,
+    AmiUtilityService $ami_utility,
+    EntityTypeManagerInterface $entity_type_manager,
+    RequestStack $request_stack,
+    RendererInterface $renderer,
+    ConfigFactoryInterface $config_factory
+  ) {
+    $this->stringTranslation = $string_translation;
+    $this->messenger = $messenger;
+    $this->loggerFactory = $logger_factory;
+    $this->account = $account;
+    $this->AmiUtilityService = $ami_utility;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->requestStack = $request_stack;
+    $this->renderer = $renderer;
+    $this->configFactory = $config_factory;
+  }
+
+
+  /**
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function onEntityPresave(StrawberryfieldCrudEvent $event) {
+
+    /*
+     * $request = $event->getRequest();
+    if ($request->getRequestFormat() !== 'api_json') {
+      return;
+    }
+
+
+    if (empty($processed_metadata)) {
+      $message = $this->t('Sorry, ADO with @uuid is empty or has wrong data/metadata. Check your data ROW in your CSV for set @setid or your Set Configuration for manually entered JSON that may break your setup.',[
+        '@uuid' => $data->info['row']['uuid'],
+        '@setid' => $data->info['set_id']
+      ]);
+      $this->messenger->addWarning($message);
+      $this->loggerFactory->get('ami')->error($message);
+      return;
+    }
+
+
+     */
+    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity*/
+    $entity = $event->getEntity();
+    $sbf_fields = $event->getFields();
+
+    foreach ($sbf_fields as $field_name) {
+      /** @var \Drupal\Core\Field\FieldItemInterface $field*/
+      $field = $entity->get($field_name);
+      /** @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
+      if (!$field->isEmpty()) {
+        $entity = $field->getEntity();
+        /** @var $field \Drupal\Core\Field\FieldItemList */
+        foreach ($field->getIterator() as $delta => $itemfield) {
+          /** @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $itemfield */
+          $fullvalues = $itemfield->provideDecoded(TRUE);
+
+          if (!is_array($fullvalues)) {
+            break;
+          }
+          /*
+          We will search for ap:tasks ap:ami entry and process from there.
+          If not we simply break and let the event Subscriber flow continue()
+          "ap:ami": { metadata_display: 7, "entity:files": { "images": ["http://some.com/remote_file.jpeg"] }
+
+          */
+          /** @var \Drupal\format_strawberryfield\MetadataDisplayInterface|null $metadatadisplay_entity */
+          $metadatadisplay_entity = NULL;
+          if (isset($fullvalues['ap:tasks']['ap:ami']['metadata_display'])) {
+            $ap_ami = $fullvalues['ap:tasks']['ap:ami'];
+            if (is_numeric($ap_ami['metadata_display'])) {
+              $metadatadisplay_entity = $this->entityTypeManager->getStorage('metadatadisplay_entity')
+                ->load($ap_ami['metadata_display']);
+            }
+            elseif (is_string($ap_ami['metadata_display']) && Uuid::isValid($ap_ami['metadata_display'])) {
+              $metadatadisplay_entity = $this->entityTypeManager->getStorage('metadatadisplay_entity')
+                ->loadByProperties(['uuid' => $ap_ami['metadata_display']]);
+              $metadatadisplay_entity = reset($metadatadisplay_entity);
+            }
+            if (!$metadatadisplay_entity) {
+              // If JSON API we must trigger an exception event here.
+              break;
+            }
+            if ($metadatadisplay_entity->get('mimetype') !== 'application/json') {
+              // If JSON API we must trigger an exception event here.
+              break;
+            }
+            // Remove since this can not persist/be part of the transformation
+            unset($fullvalues['ap:tasks']['ap:ami']);
+            // For safety we will also strip any further ap:ami key after the process
+            // in case the user ends adding a new one and we end with possible
+            // infinite loop of transforms? TBH is not possible. But
+            // Could at least have the consequences that after any EDIT
+            // a new transforms triggers? Which is bad? Well might be even intended!
+            // @TODO what are the benefits? an everlasting automatic cleanup template?
+            $context['node'] = $entity;
+            $context['data'] = $fullvalues;
+            $context['iiif_server'] = $this->configFactory->get('format_strawberryfield.iiif_settings')->get('pub_server_url');
+            $original_context = $context;
+            // Allow other modules to provide extra Context!
+            // Call modules that implement the hook, and let them add items.
+            \Drupal::moduleHandler()->alter('format_strawberryfield_twigcontext', $context);
+            // In case someone decided to wipe the original context?
+            // We bring it back!
+            $context = $context + $original_context;
+
+            // @see https://www.drupal.org/node/2638686 to understand
+            // What cacheable, Bubbleable metadata and early rendering means.
+            try {
+              $cacheabledata = $this->renderer->executeInRenderContext(
+                new RenderContext(),
+                function () use ($context, $metadatadisplay_entity) {
+                  return $metadatadisplay_entity->renderNative($context);
+                }
+              );
+              if (count($cacheabledata)) {
+                $jsonstring = $cacheabledata->__toString();
+                $jsondata = json_decode($jsonstring, TRUE);
+                $json_error = json_last_error();
+                // To avoid passing the original data into the template transformed
+                // data back. See @TODO about if this is desireable.
+                if ($json_error != JSON_ERROR_NONE) {
+                  $message = $this->t(
+                    'We could not generate JSON via Metadata Display "@metadatadisplay" into ADO with UUID @uuid. This is the Template %output',
+                    [
+                      '@metadatadisplay' => $metadatadisplay_entity->label(),
+                      '@uuid'              => $entity->uuid(),
+                      '%output'            => $jsonstring,
+                    ]
+                  );
+                  $this->loggerFactory->get('ami')->error($message);
+                  break;
+                }
+                unset($jsondata['ap:tasks']['ap:ami']);
+                if (!$itemfield->setMainValueFromArray((array) $jsondata)) {
+                  $message = $this->t(
+                    'We could not persist correct JSON via Metadata Display "@metadatadisplay" into future ADO with UUID @uuid.',
+                    [
+                      '@metadatadisplayid' => $metadatadisplay_entity->label(),
+                      '@uuid'              => $entity->uuid(),
+                    ]
+                  );
+                  $this->loggerFactory->get('ami')->error($message);
+                }
+              }
+            }
+            catch (\Exception $e) {
+              $message = $this->t(
+                'We could not generate JSON via Metadata Display "@metadatadisplay" into ADO with UUID @uuid. This is the exception %output',
+                [
+                  '@metadatadisplayid' => $metadatadisplay_entity->label(),
+                  '@uuid'              => $entity->uuid(),
+                  '%output'            => $e->getMessage(),
+                ]
+              );
+              $this->loggerFactory->get('ami')->error($message);
+              break;
+            }
+          }
+        }
+      }
+    }
+    $current_class = get_called_class();
+    $event->setProcessedBy($current_class, TRUE);
+  }
+}

--- a/src/EventSubscriber/AmiStrawberryfieldEventPresaveSubscriberJsonTransform.php
+++ b/src/EventSubscriber/AmiStrawberryfieldEventPresaveSubscriberJsonTransform.php
@@ -102,8 +102,8 @@ class AmiStrawberryfieldEventPresaveSubscriberJsonTransform extends Strawberryfi
   public function __construct(
     TranslationInterface $string_translation,
     MessengerInterface $messenger,
-    AccountInterface $account,
     LoggerChannelFactoryInterface $logger_factory,
+    AccountInterface $account,
     AmiUtilityService $ami_utility,
     EntityTypeManagerInterface $entity_type_manager,
     RequestStack $request_stack,
@@ -190,7 +190,8 @@ class AmiStrawberryfieldEventPresaveSubscriberJsonTransform extends Strawberryfi
               // If JSON API we must trigger an exception event here.
               break;
             }
-            if ($metadatadisplay_entity->get('mimetype') !== 'application/json') {
+
+            if ($metadatadisplay_entity->get('mimetype')->first()->getValue()['value'] !== 'application/json') {
               // If JSON API we must trigger an exception event here.
               break;
             }

--- a/src/Form/AmiMultiStepIngestBaseForm.php
+++ b/src/Form/AmiMultiStepIngestBaseForm.php
@@ -43,7 +43,7 @@ class AmiMultiStepIngestBaseForm extends FormBase {
   private $currentUser;
 
   /**
-   * @var \Drupal\user\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $store;
 

--- a/src/Form/amiSetEntityDeleteProcessedForm.php
+++ b/src/Form/amiSetEntityDeleteProcessedForm.php
@@ -2,6 +2,7 @@
 namespace Drupal\ami\Form;
 
 use Drupal\ami\AmiUtilityService;
+use Drupal\ami\Entity\amiSetEntity;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\ContentEntityConfirmFormBase;
 use Drupal\Core\Entity\EntityRepositoryInterface;
@@ -103,7 +104,7 @@ class amiSetEntityDeleteProcessedForm extends ContentEntityConfirmFormBase {
         'operations' => $operations,
         'finished' => '\Drupal\ami\Form\amiSetEntityDeleteProcessedForm::batchFinished',
       );
-      $this->entity->setStatus(\Drupal\ami\Entity\amiSetEntity::STATUS_ENTITIES_DELETED);
+      $this->entity->setStatus(amiSetEntity::STATUS_ENTITIES_DELETED);
       $this->entity->save();
       $form_state->setRedirectUrl($this->getCancelUrl());
       batch_set($batch);

--- a/src/Form/amiSetEntityDeleteProcessedForm.php
+++ b/src/Form/amiSetEntityDeleteProcessedForm.php
@@ -94,7 +94,7 @@ class amiSetEntityDeleteProcessedForm extends ContentEntityConfirmFormBase {
         return;
       }
       $operations = [];
-      foreach (array_chunk($uuids, 10) as $batch_data_uuid) {
+      foreach (array_chunk($uuids, 50) as $batch_data_uuid) {
         $operations[] = ['\Drupal\ami\Form\amiSetEntityDeleteProcessedForm::batchDelete'
           , [$batch_data_uuid]];
       }

--- a/src/Form/amiSetEntityDeleteProcessedForm.php
+++ b/src/Form/amiSetEntityDeleteProcessedForm.php
@@ -103,6 +103,9 @@ class amiSetEntityDeleteProcessedForm extends ContentEntityConfirmFormBase {
         'operations' => $operations,
         'finished' => '\Drupal\ami\Form\amiSetEntityDeleteProcessedForm::batchFinished',
       );
+      $this->entity->setStatus(\Drupal\ami\Entity\amiSetEntity::STATUS_ENTITIES_DELETED);
+      $this->entity->save();
+      $form_state->setRedirectUrl($this->getCancelUrl());
       batch_set($batch);
     } else {
       $this->messenger()->addError(
@@ -176,10 +179,12 @@ class amiSetEntityDeleteProcessedForm extends ContentEntityConfirmFormBase {
 
   // What to do after batch ran. Display success or error message.
   public static function batchFinished($success, $results, $operations) {
-    if ($success)
-      $message = count($results). ' batches processed.';
-    else
+    if ($success) {
+      $message = count($results) . ' batches processed.';
+    }
+    else {
       $message = 'Finished with an error.';
+    }
 
     $messenger = \Drupal::messenger();
     if (isset($message)) {

--- a/src/Form/amiSetEntityProcessForm.php
+++ b/src/Form/amiSetEntityProcessForm.php
@@ -191,6 +191,8 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
             ]
           )
         );
+        $this->entity->setStatus(\Drupal\ami\Entity\amiSetEntity::STATUS_ENQUEUED);
+        $this->entity->save();
         $form_state->setRedirectUrl($this->getCancelUrl());
       }
       else {
@@ -409,6 +411,8 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
       '\Drupal\ami\AmiBatchQueue::takeOne',
       [$queue_name, $this->entity->id()],
     ];
+    $this->entity->setStatus(\Drupal\ami\Entity\amiSetEntity::STATUS_PROCESSING);
+    $this->entity->save();
     batch_set($batch);
   }
 

--- a/src/Form/amiSetEntityProcessForm.php
+++ b/src/Form/amiSetEntityProcessForm.php
@@ -130,6 +130,9 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
 
       $SetURL = $this->entity->toUrl('canonical', ['absolute' => TRUE])
         ->toString();
+      $run_timestamp = $this->time->getCurrentTime();
+
+
       $notprocessnow = $form_state->getValue('not_process_now', NULL);
       $queue_name = 'ami_ingest_ado';
       if (!$notprocessnow) {
@@ -173,6 +176,7 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
           'manyfiles' => $manyfiles,
           'ops_skip_onmissing_file' => $ops_skip_onmissing_file,
           'ops_forcemanaged_destination_file' => $ops_forcemanaged_destination_file,
+          'time_submitted' => $run_timestamp
         ];
         $added[] = \Drupal::queue($queue_name)
           ->createItem($data);

--- a/src/Form/amiSetEntityProcessForm.php
+++ b/src/Form/amiSetEntityProcessForm.php
@@ -76,8 +76,8 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $manyfiles = $this->configFactory()->get('strawberryfield.filepersister_service_settings')->get('manyfiles') ?? 0;
     $statuses = $form_state->getValue('status', []);
-    $ops_skip_onmissing_file = $form_state->getValue('skip_onmissing_file', TRUE);
-    $ops_forcemanaged_destination_file = $form_state->getValue('take_control_file', TRUE);
+    $ops_skip_onmissing_file = (bool) $form_state->getValue('skip_onmissing_file', TRUE);
+    $ops_forcemanaged_destination_file = (bool) $form_state->getValue('take_control_file', TRUE);
 
     $csv_file_reference = $this->entity->get('source_data')->getValue();
     if (isset($csv_file_reference[0]['target_id'])) {
@@ -299,7 +299,7 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
       $form['take_control_file'] = [
         '#type' => 'checkbox',
         '#title' => $this->t("Let Archipelago organize my files"),
-        '#description' => $this->t("If enabled all files referenced in this AMI set that share with this repositories configured <em>Storage Scheme for Persisting Files</em> will be copied into an Archipelago managed location and sanitized. If disabled those files will maintain its original location and it will be up to the manager to ensure they are not removed from there."),
+        '#description' => $this->t("If enabled all files referenced in this AMI set that share with this repositories configured <em>Storage Scheme for Persisting Files</em> will be copied into an Archipelago managed location and sanitized.<br> If disabled those files will maintain its original location and it will be up to the manager to ensure they are not removed from there."),
         '#default_value' => TRUE,
         '#access' =>  $this->currentUser()->hasPermission('override file destination ami entity') || $this->currentUser()->hasRole('administrator'),
       ];

--- a/src/Form/amiSetEntityProcessForm.php
+++ b/src/Form/amiSetEntityProcessForm.php
@@ -142,6 +142,7 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
 
       $SetURL = $this->entity->toUrl('canonical', ['absolute' => TRUE])
         ->toString();
+
       $run_timestamp = $this->time->getCurrentTime();
 
 

--- a/src/Form/amiSetEntityProcessForm.php
+++ b/src/Form/amiSetEntityProcessForm.php
@@ -296,13 +296,21 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
         '#description' => $this->t("If enabled a referenced missed file or one that can not be processed from the source, remote or local will make AMI skip the affected ROW. Enabled by default for better QA during processing."),
         '#default_value' => TRUE,
       ];
-      $form['take_control_file'] = [
-        '#type' => 'checkbox',
-        '#title' => $this->t("Let Archipelago organize my files"),
-        '#description' => $this->t("If enabled all files referenced in this AMI set that share with this repositories configured <em>Storage Scheme for Persisting Files</em> will be copied into an Archipelago managed location and sanitized.<br> If disabled those files will maintain its original location and it will be up to the manager to ensure they are not removed from there."),
-        '#default_value' => TRUE,
-        '#access' =>  $this->currentUser()->hasPermission('override file destination ami entity') || $this->currentUser()->hasRole('administrator'),
-      ];
+      $config = \Drupal::config('strawberryfield.general');
+      if ($config->get('override_persistent_storage') === TRUE) {
+        $form['take_control_file'] = [
+          '#type'          => 'checkbox',
+          '#title'         => $this->t("Let Archipelago organize my files"),
+          '#description'   => $this->t(
+            "Enabled by default. All files referenced in this AMI set will be copied into an Archipelago managed location and sanitized.<br> Danger: If disabled files that share source location with this repositories configured <em>Storage Scheme for Persisting Files</em> will maintain its original location and it will be up to the manager to ensure they are not removed from there."
+          ),
+          '#default_value' => TRUE,
+          '#access'        => $this->currentUser()->hasPermission(
+              'override file destination ami entity'
+            )
+            || $this->currentUser()->hasRole('administrator'),
+        ];
+      }
 
       $form['status'] = [
         '#tree' => TRUE,
@@ -371,7 +379,7 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
           'Re download and reprocess every file'
         ),
         '#description' => $this->t(
-          'Check this to force every file attached to an ADO to be downloaded and characterized again, even if on a previous Batch run that data was already generated for reuse. Needed if e.g the URL of a file is the same but the remote source changed.'
+          'Check this to force every file attached to an ADO to be downloaded and characterized again, even if on a previous Batch run that data was already generated for reuse. IMPORTANT: Needed if e.g the URL of a file is the same but the remote source changed, if you have custom code that modifies the backend naming strategy of files.'
         ),
         '#required' => FALSE,
         '#default_value' => FALSE,

--- a/src/Form/amiSetEntityReportForm.php
+++ b/src/Form/amiSetEntityReportForm.php
@@ -183,7 +183,6 @@ class amiSetEntityReportForm extends ContentEntityConfirmFormBase {
             if (json_last_error() == JSON_ERROR_NONE) {
               $current_time_stamp = isset($currentLineExpanded['context']['time_submitted']) ? $currentLineExpanded['context']['time_submitted'] : $prev_time_stamp;
               if ($prev_time_stamp != NULL && $current_time_stamp != $prev_time_stamp) {
-                error_log($current_time_stamp);
                 $endcurrent = TRUE; // Double safety? I'm already bailing ...
                 break 2;
               }
@@ -191,8 +190,6 @@ class amiSetEntityReportForm extends ContentEntityConfirmFormBase {
                 if (isset($currentLineExpanded['level_name']) && $currentLineExpanded['level_name'] == $level) {
                   $total_lines_current++;
                 }
-                error_log($prev_time_stamp);
-                error_log($current_time_stamp);
                 $prev_time_stamp = $current_time_stamp;
               }
             }
@@ -245,14 +242,14 @@ class amiSetEntityReportForm extends ContentEntityConfirmFormBase {
             $row = ['Wrong Format for this entry', '', '', $line];
             array_unshift($rows, $row);
           }
-        if (count($rows) ==  $num_per_page) { break;}
+          if (count($rows) ==  $num_per_page) { break;}
         }
-      // Now check if we have less than $num_per_page
-      // And $offset > 0;
-      if (count($rows) <  $num_per_page) {
-        $offset = $offset - $num_per_page;
-        $offset = $offset < 0 ? 0 : $offset;
-       }
+        // Now check if we have less than $num_per_page
+        // And $offset > 0;
+        if (count($rows) <  $num_per_page) {
+          $offset = $offset - $num_per_page;
+          $offset = $offset < 0 ? 0 : $offset;
+        }
       }
       $file = NULL;
 
@@ -265,10 +262,10 @@ class amiSetEntityReportForm extends ContentEntityConfirmFormBase {
           'Info'
         ),
         '#markup' => $this->t(
-          'You have @count entries for your current Filter and last Processed time of this set was @date', [
+          'You have @count entries for your current Filter and last Processed time of this set was <em>@date</em>', [
             '@count' => $total_lines_for_pager,
             '@date' => !empty($prev_time_stamp) ? date('D, d M Y \a\t H:i:s', $prev_time_stamp) : " Unknown "
-      ]
+          ]
         ),
         'level'   => [
           '#type'          => 'select',

--- a/src/Form/amiSetEntityReportForm.php
+++ b/src/Form/amiSetEntityReportForm.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace Drupal\ami\Form;
+
+use Drupal\ami\AmiLoDService;
+use Drupal\ami\AmiUtilityService;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\ContentEntityConfirmFormBase;
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Form controller for the MetadataDisplayEntity entity delete form.
+ *
+ * @ingroup ami
+ */
+class amiSetEntityReportForm extends ContentEntityForm {
+
+  /**
+   * @var \Drupal\ami\AmiUtilityService
+   */
+  protected $AmiUtilityService;
+
+  /**
+   * File system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * Constructs a ContentEntityForm object.
+   *
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface          $entity_repository
+   *   The entity repository service.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface|null $entity_type_bundle_info
+   *   The entity type bundle service.
+   * @param \Drupal\Component\Datetime\TimeInterface|null          $time
+   *   The AMI Utility service.
+   * @param \Drupal\ami\AmiUtilityService                          $ami_utility
+   *   The AMI LoD service.
+   * @param \Drupal\Core\File\FileSystemInterface                  $file_system
+   */
+  public function __construct(
+    EntityRepositoryInterface $entity_repository,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL,
+    TimeInterface $time = NULL, AmiUtilityService $ami_utility, FileSystemInterface $file_system) {
+    parent::__construct($entity_repository, $entity_type_bundle_info, $time);
+    $this->AmiUtilityService = $ami_utility;
+    $this->fileSystem = $file_system;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.repository'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('datetime.time'),
+      $container->get('ami.utility'),
+      $container->get('file_system')
+    );
+  }
+
+  public function getConfirmText() {
+    return $this->t('Save Current LoD Page');
+  }
+
+
+  public function getQuestion() {
+    return $this->t(
+      'Are you sure you want to Save Modified Reconcile Lod for %name?',
+      ['%name' => $this->entity->label()]
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('entity.ami_set_entity.collection');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function actions(array $form, FormStateInterface $form_state) {
+    $actions = parent::actions($form, $form_state);
+    $actions['submit_download'] = [
+      '#type' => 'submit',
+      '#value' => t('Download Logs'),
+      '#submit' => [
+        [$this, 'submitFormDownload'],
+      ],
+    ];
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    // Read Config first to get the Selected Bundles based on the Config
+    // type selected. Based on that we can set Moderation Options here
+
+    $data = new \stdClass();
+    foreach ($this->entity->get('set') as $item) {
+      /** @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $item */
+      $data = $item->provideDecoded(FALSE);
+    }
+    $logfilename = "private://ami/logs/set{$this->entity->id()}.log";
+    $logfilename = $this->fileSystem->realpath($logfilename);
+    $last_op = NULL;
+    if ($logfilename !== FALSE && file_exists($logfilename)) {
+      $fp = fopen($this->fileSystem->realpath($logfilename), 'r');
+      $pos = -2; // Skip final new line character (Set to -1 if not present)
+      $rows = [];
+      $currentLine = '';
+      $line_count = 0;
+      while (-1 !== fseek($fp, $pos, SEEK_END)) {
+        $char = fgetc($fp);
+        if (PHP_EOL == $char) {
+          $line_count++;
+          $currentLineExpanded = json_decode($currentLine, TRUE);
+          if (json_last_error() == JSON_ERROR_NONE) {
+            $row = [];
+            $row['datetime'] = $currentLineExpanded['datetime'];
+            $row['level'] = $currentLineExpanded['level_name'];
+            $row['message'] = $this->t($currentLineExpanded['message'], []);
+            $row['details']  = json_encode($currentLineExpanded['context']);
+            $rows[] = $row;
+          }
+          $currentLine = '';
+        }
+        else {
+          $currentLine = $char . $currentLine;
+        }
+        $pos--;
+        if ($line_count == 50) {
+          break;
+        }
+      }
+
+     $currentLineExpanded = json_decode($currentLine, TRUE);
+      if (json_last_error() == JSON_ERROR_NONE) {
+        $row = [];
+        $row['datetime'] = $currentLineExpanded['datetime'];
+        $row['level'] = $currentLineExpanded['level_name'];
+        $row['message'] = $this->t($currentLineExpanded['message'], []);
+        $row['details']  = json_encode($currentLineExpanded['context']);
+        $rows[] = $row;
+      }
+      $form['status'] = [
+        '#tree'   => TRUE,
+        '#type'   => 'fieldset',
+        '#title'  => $this->t(
+          'Info'
+        ),
+        '#markup' => $this->t(
+          'Your last Process logs'
+        ),
+        'logs' => [
+          '#type' => 'table',
+          '#header' => [
+            $this->t('datetime'),
+            $this->t('level'),
+            $this->t('message'),
+            $this->t('details'),
+          ],
+          '#rows' => $rows,
+          '#sticky' => TRUE,
+        ]
+      ];
+    }
+    else {
+      $form['status'] = [
+        '#tree'   => TRUE,
+        '#type'   => 'fieldset',
+        '#title'  => $this->t(
+          'Info'
+        ),
+        '#markup' => $this->t(
+          'Sorry. No Logs have been generated yet.'
+        ),
+      ];
+    }
+    return $form;
+
+
+
+
+    $csv_file_processed = $this->entity->get('processed_data')->getValue();
+    if (isset($csv_file_processed[0]['target_id'])) {
+      /** @var \Drupal\file\Entity\File $file_lod */
+      $file_lod = $this->entityTypeManager->getStorage('file')->load(
+        $csv_file_processed[0]['target_id']);
+
+      if ($data !== new \stdClass()) {
+        // Only Show this form if we got data from the SBF field.
+        // we can't assume the user did not mess with the AMI set data?
+        $op = $data->pluginconfig->op ?? NULL;
+        $ops = [
+          'create',
+          'update',
+          'patch',
+        ];
+        if (!in_array($op, $ops)) {
+          $form['status'] = [
+            '#tree' => TRUE,
+            '#type' => 'fieldset',
+            '#title' => $this->t(
+              'Error'
+            ),
+            '#markup' => $this->t(
+              'Sorry. This AMI set has no right Operation (Create, Update, Patch) set. Please fix this or contact your System Admin to fix it.'
+            ),
+          ];
+          return $form;
+        }
+        $form['lod_cleanup'] = [
+          '#tree' => TRUE,
+          '#type' => 'fieldset',
+          '#title' => $this->t('LoD reconciled Clean Up'),
+        ];
+
+        if ($file_lod) {
+          $num_per_page = 10;
+          $total_rows =  $this->AmiUtilityService->csv_count($file_lod, FALSE);
+          // Remove the header in the calculations.
+          $total_rows = $total_rows - 1;
+          $pager = \Drupal::service('pager.manager')->createPager($total_rows, $num_per_page);
+          $page = $pager->getCurrentPage();
+          $offset = $num_per_page * $page;
+          if (PHP_VERSION_ID > 80000) {
+            // @TODO fgetcsv has a bug when called after a seek, offsets on 1 always.
+            // We are trying to skip the header too (but get it)
+            //$offset  = $offset + 2;
+            // @TODO CHECK IF THIS WILL WORK ON PHP 8.x when we get there.
+          }
+          $file_data_all = $this->AmiUtilityService->csv_read($file_lod, $offset, $num_per_page, TRUE, FALSE);
+
+          $column_keys = $file_data_all['headers'] ?? [];
+          $form['lod_cleanup']['pager_top'] = ['#type' => 'pager'];
+          $form['lod_cleanup']['table-row'] = [
+            '#type' => 'table',
+            '#tree' => TRUE,
+            '#prefix' => '<div id="table-fieldset-wrapper">',
+            '#suffix' => '</div>',
+            '#header' => $column_keys,
+            '#empty' => $this->t('Sorry, There are LoD no items or you have not a header column. Check your CSV for errors.'),
+          ];
+          $elements = [];
+          $form['lod_cleanup']['offset'] = [
+            '#type' => 'value',
+            '#value' => $offset,
+          ];
+          $form['lod_cleanup']['num_per_page'] = [
+            '#type' => 'value',
+            '#value' => $num_per_page,
+          ];
+          $form['lod_cleanup']['column_keys'] = [
+            '#type' => 'value',
+            '#value' => $column_keys,
+          ];
+          $form['lod_cleanup']['total_rows'] = [
+            '#type' => 'value',
+            '#value' => $total_rows,
+          ];
+
+
+          foreach ($column_keys as $column) {
+            if ($column !== 'original' && $column != 'csv_columns' && $column !='checked') {
+              $argument_string = $this->AmiLoDService::LOD_COLUMN_TO_ARGUMENTS[$column] ?? NULL;
+              if ($argument_string) {
+                $arguments = explode(';', $argument_string);
+                $elements[$column] = [
+                  '#type' => 'webform_metadata_' . $arguments[0],
+                  '#title' => implode(' ', $arguments),
+                ];
+
+                if ($arguments[1] == 'rdftype') {
+                  $elements[$column]['#rdftype'] = $arguments[2] ?? '';
+                  $elements[$column]['#vocab'] = 'rdftype';
+                }
+                else {
+                  $elements[$column]['#vocab'] = $arguments[1] ?? '';
+                }
+
+              }
+              else {
+                // Fallback to WIKIDATA
+                $elements[$column] = ['#type' => 'webform_metadata_wikidata'];
+              }
+            }
+          }
+          $original_index = array_search('original', $column_keys);
+          foreach ($file_data_all['data'] as $index => $row) {
+            // Find the label first
+            $label = $row[$original_index];
+            $persisted_lod_reconciliation = $this->AmiLoDService->getKeyValuePerAmiSet($label, $this->entity->id());
+            foreach($file_data_all['headers'] as $key => $header) {
+              if ($header == 'original' || $header == 'csv_columns') {
+                $form['lod_cleanup']['table-row'][($index - 1)][$header.'-'.($index-1)] = [
+                  '#type' => 'markup',
+                  '#markup' => $row[$key],
+                  $header.'-'.($index-1) => [
+                    '#tree' => true,
+                    '#type' => 'hidden',
+                    '#value' => $row[$key],
+                  ]
+                ];
+              }
+              elseif ($header == 'checked') {
+                $checked = $persisted_lod_reconciliation[$header] ?? $row[$key];
+                $checked = (bool) $checked;
+                $form['lod_cleanup']['table-row'][($index - 1)][$header.'-'.($index-1)] = [
+                  '#type' => 'checkbox',
+                  '#default_value' => $checked,
+                  '#title' => $this->t('revisioned'),
+                ];
+              }
+              else {
+                // Given the incremental save option we have now
+                // We need to load check first if there is
+                // A Key Value equivalent of the row
+
+                $form['lod_cleanup']['table-row'][($index - 1)][$header.'-'.($index-1)] = [
+                    '#multiple' => 5,
+                    '#multiple__header' => FALSE,
+                    '#multiple__no_items_message' => '',
+                    '#multiple__min_items' => 1,
+                    '#multiple__empty_items' => 0,
+                    '#multiple__sorting' => FALSE,
+                    '#multiple__add_more' => FALSE,
+                    '#multiple__add_more_input' => FALSE,
+                    '#label__title' => 'Label',
+                    '#default_value' => $persisted_lod_reconciliation[$header]['lod'] ?? json_decode($row[$key], TRUE),
+                  ] +  $elements[$header];
+              }
+            }
+          }
+          \Drupal::service('plugin.manager.webform.element')->processElements($form);
+          // Attach the webform library.
+          $form['#attached']['library'][] = 'webform/webform.form';
+          $form['lod_cleanup']['pager'] = ['#type' => 'pager'];
+        }
+      }
+      $form = $form + parent::buildForm($form, $form_state);
+      return $form;
+    }
+    else {
+      $form['status'] = [
+        '#tree' => TRUE,
+        '#type' => 'fieldset',
+        '#title' =>  $this->t(
+          'No Reconciled LoD Found.'
+        ),
+        '#markup' => $this->t(
+          'Start by visiting the <em>LoD Reconcile</em> tab and running a reconciliation. Once done you can come back here.'
+        ),
+      ];
+      return $form;
+    }
+  }
+
+
+
+
+}
+

--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -184,7 +184,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
     // This will add the File logger not replace the DB
     // IF we want to only use the file logger we should use setLogger([$log]);
     $this->loggerFactory->get('ami')->addLogger($log);
-   
+
     /* Data info for an ADO has this structure
       $data->info = [
         'row' => The actual data
@@ -961,6 +961,9 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
       if (!$file) {
         $data->info['force_file_process'] = TRUE;
         // OK still there and alive. If not we have to force reprocessing!
+      }
+      elseif (file_exists($file->getFileUri()) == FALSE) {
+        $data->info['force_file_process'] = TRUE;
       }
     }
     else {

--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -184,14 +184,17 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
    * {@inheritdoc}
    */
   public function processItem($data) {
-    $log = new Logger('ami');
+    $log = new Logger('ami_file');
     $private_path = \Drupal::service('stream_wrapper_manager')->getViaUri('private://')->getDirectoryPath();
     $handler = new StreamHandler($private_path.'/ami/logs/set'.$data->info['set_id'].'.log', Logger::DEBUG);
     $handler->setFormatter(new JsonFormatter());
     $log->pushHandler($handler);
     // This will add the File logger not replace the DB
-    // IF we want to only use the file logger we should use setLogger([$log]);
-    $this->loggerFactory->get('ami')->addLogger($log);
+    // We can not use addLogger because in a single PHP process multiple Queue items might be invoked
+    // And loggers are additive. Means i can end with a few duplicated entries!
+    // @TODO: i should inject this into the Containers but i wanted to keep
+    // it simple for now.
+    $this->loggerFactory->get('ami_file')->setLoggers([[$log]]);
 
     /* Data info for an ADO has this structure
       $data->info = [
@@ -259,7 +262,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
             '@setid' => $data->info['set_id'],
             '@parent_uuids' => implode(',', $parent_uuids)
           ]);
-          $this->loggerFactory->get('ami')->warning($message ,[
+          $this->loggerFactory->get('ami_file')->warning($message ,[
             'setid' => $data->info['set_id'] ?? NULL,
             'time_submitted' => $data->info['time_submitted'] ?? '',
           ]);
@@ -276,7 +279,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
               '@uuid' => $data->info['row']['uuid'],
               '@setid' => $data->info['set_id']
             ]);
-            $this->loggerFactory->get('ami')->error($message ,[
+            $this->loggerFactory->get('ami_file')->error($message ,[
               'setid' => $data->info['set_id'] ?? NULL,
               'time_submitted' => $data->info['time_submitted'] ?? '',
             ]);
@@ -314,7 +317,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
           '@uuid' => $data->info['row']['uuid'],
           '@setid' => $data->info['set_id']
         ]);
-        $this->loggerFactory->get('ami')->error($message ,[
+        $this->loggerFactory->get('ami_file')->error($message ,[
           'setid' => $data->info['set_id'] ?? NULL,
           'time_submitted' => $data->info['time_submitted'] ?? '',
         ]);
@@ -329,7 +332,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
           '@setid' => $data->info['set_id']
         ]);
 
-        $this->loggerFactory->get('ami')->error($message ,[
+        $this->loggerFactory->get('ami_file')->error($message ,[
           'setid' => $data->info['set_id'] ?? NULL,
           'time_submitted' => $data->info['time_submitted'] ?? '',
         ]);
@@ -341,7 +344,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
           [
             '@setid' => $data->info['set_id'],
           ]);
-        $this->loggerFactory->get('ami')->error($message ,[
+        $this->loggerFactory->get('ami_file')->error($message ,[
           'setid' => $data->info['set_id'] ?? NULL,
           'time_submitted' => $data->info['time_submitted'] ?? '',
         ]);
@@ -357,7 +360,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
           '@uuid' => $data->info['row']['uuid'],
           '@setid' => $data->info['set_id']
         ]);
-        $this->loggerFactory->get('ami')->error($message ,[
+        $this->loggerFactory->get('ami_file')->error($message ,[
           'setid' => $data->info['set_id'] ?? NULL,
           'time_submitted' => $data->info['time_submitted'] ?? '',
         ]);
@@ -377,7 +380,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
         '@uuid' => $data->info['row']['uuid'],
         '@setid' => $data->info['set_id']
       ]);
-      $this->loggerFactory->get('ami')->error($message ,[
+      $this->loggerFactory->get('ami_file')->error($message ,[
         'setid' => $data->info['set_id'] ?? NULL,
         'time_submitted' => $data->info['time_submitted'] ?? '',
       ]);
@@ -516,7 +519,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
                     '@filename' => $filename,
                     '@filecolumn' => $file_column,
                   ]);
-                $this->loggerFactory->get('ami')->warning($message ,[
+                $this->loggerFactory->get('ami_file')->warning($message ,[
                   'setid' => $data->info['set_id'] ?? NULL,
                   'time_submitted' => $data->info['time_submitted'] ?? '',
                 ]);
@@ -549,7 +552,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
           '@uuid' => $data->info['row']['uuid'],
           '@setid' => $data->info['set_id'],
         ]);
-      $this->loggerFactory->get('ami')->warning($message ,[
+      $this->loggerFactory->get('ami_file')->warning($message ,[
         'setid' => $data->info['set_id'] ?? NULL,
         'time_submitted' => $data->info['time_submitted'] ?? '',
       ]);
@@ -623,7 +626,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
         '@uuid' => $data->info['row']['uuid'],
         '@setid' => $data->info['set_id']
       ]);
-      $this->loggerFactory->get('ami')->error($message ,[
+      $this->loggerFactory->get('ami_file')->error($message ,[
         'setid' => $data->info['set_id'] ?? NULL,
         'time_submitted' => $data->info['time_submitted'] ?? '',
       ]);
@@ -864,7 +867,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
           '%title' => $label,
           '@ophuman' => static::OP_HUMAN[$op]
         ]);
-        $this->loggerFactory->get('ami')->info($message ,[
+        $this->loggerFactory->get('ami_file')->info($message ,[
           'setid' => $data->info['set_id'] ?? NULL,
           'time_submitted' => $data->info['time_submitted'] ?? '',
         ]);
@@ -876,7 +879,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
           '@setid' => $data->info['set_id'],
           '@ophuman' => static::OP_HUMAN[$op],
         ]);
-        $this->loggerFactory->get('ami')->error($message ,[
+        $this->loggerFactory->get('ami_file')->error($message ,[
           'setid' => $data->info['set_id'] ?? NULL,
           'time_submitted' => $data->info['time_submitted'] ?? '',
         ]);
@@ -890,7 +893,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
         '@setid' => $data->info['set_id'],
         '@ophuman' => static::OP_HUMAN[$op],
       ]);
-      $this->loggerFactory->get('ami')->info($message ,[
+      $this->loggerFactory->get('ami_file')->info($message ,[
         'setid' => $data->info['set_id'] ?? NULL,
         'time_submitted' => $data->info['time_submitted'] ?? '',
       ]);
@@ -1006,7 +1009,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
             '@setid' => $data->info['set_id'],
             '@filename' => $data->info['filename']
           ]);
-        $this->loggerFactory->get('ami')->warning($message ,[
+        $this->loggerFactory->get('ami_file')->warning($message ,[
           'setid' => $data->info['set_id'] ?? NULL,
           'time_submitted' => $data->info['time_submitted'] ?? '',
         ]);
@@ -1045,7 +1048,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
         '@setid' => $data->info['set_id']
       ]);
 
-      $this->loggerFactory->get('ami')->warning($message ,[
+      $this->loggerFactory->get('ami_file')->warning($message ,[
         'setid' => $data->info['set_id'] ?? NULL,
         'time_submitted' => $data->info['time_submitted'] ?? '',
       ]);
@@ -1058,7 +1061,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
         '@setid' => $data->info['set_id'],
         '@ophuman' => static::OP_HUMAN[$data->pluginconfig->op],
       ]);
-      $this->loggerFactory->get('ami')->warning($message ,[
+      $this->loggerFactory->get('ami_file')->warning($message ,[
         'setid' => $data->info['set_id'] ?? NULL,
         'time_submitted' => $data->info['time_submitted'] ?? '',
       ]);
@@ -1075,7 +1078,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
           '@setid' => $data->info['set_id'],
           '@ophuman' => static::OP_HUMAN[$data->pluginconfig->op],
         ]);
-        $this->loggerFactory->get('ami')->error($message ,[
+        $this->loggerFactory->get('ami_file')->error($message ,[
           'setid' => $data->info['set_id'] ?? NULL,
           'time_submitted' => $data->info['time_submitted'] ?? '',
         ]);
@@ -1144,7 +1147,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
       $message = $this->t('The original AMI Set ID @setid does not longer exist.',[
         '@setid' => $data->info['set_id']
       ]);
-      $this->loggerFactory->get('ami')->warning($message ,[
+      $this->loggerFactory->get('ami_file')->warning($message ,[
         'setid' => $data->info['set_id'] ?? NULL,
         'time_submitted' => $data->info['time_submitted'] ?? '',
       ]);

--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -362,6 +362,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
           $process_files_via_queue = TRUE;
         }
         foreach ($filenames as $filename) {
+          $filename = trim($filename);
           if (!empty($data->info['waiting_for_files'])) {
             $processed_file_data = $this->store->get('set_' . $data->info['set_id'] . '-' . md5($filename));
             if (!empty($processed_file_data['as_data']) && !empty($processed_file_data['file_id'])) {
@@ -849,7 +850,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
 
     // First check if we already have the info here, if so do nothing.
     if (($data->info['force_file_process'] ?? FALSE) || empty($this->store->get('set_' . $data->info['set_id'] . '-' . md5($data->info['filename'])))) {
-      $file = $this->AmiUtilityService->file_get($data->info['filename'],
+      $file = $this->AmiUtilityService->file_get(trim($data->info['filename']),
         $data->info['zip_file']);
       if ($file) {
         $reduced = $data->info['reduced'] ?? FALSE;

--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -184,10 +184,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
     // This will add the File logger not replace the DB
     // IF we want to only use the file logger we should use setLogger([$log]);
     $this->loggerFactory->get('ami')->addLogger($log);
-    $this->loggerFactory->get('ami')->info($this->t('Ingesting %setid',['%setid' => $data->info['set_id']]) ,[
-      'setid' => $data->info['set_id'] ?? NULL,
-      'time_submitted' => $data->info['time_submitted'] ?? '',
-    ]);
+   
     /* Data info for an ADO has this structure
       $data->info = [
         'row' => The actual data


### PR DESCRIPTION
See #8 

This involves
- New AMI Set Field where we will attach a CSV and/or append records to it on each processing
- Reports Tab where you can see by type/filter/alerts/info about the last processed set matching also 1:1 to the actual CSV data (so label/node_uuid, etc will match too + timestamp, what happened, why, etc)
- A new option for processing (enabled by default) that will skip processing a ROW leading to an ADO if any of the file processing/downloading/fetching fails. (missing file, remote disconnects, etc)

@karomabiles @alliomeria keeping you in the loop. This is my first pass, will finish ~tomorrow~ someday. Should have done this sooner!

ps:awwwwwwwww