### PR TITLE
ISSUE-124: VBO breaks after 4.1.2. Update composer.json in 0.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/core": "^8.9 || ^9",
         "ext-zip": "*",
         "ext-json": "*",
-        "drupal/views_bulk_operations": "^3.9 || ^4.1",
+        "drupal/views_bulk_operations": "^3.9 || 4.1.2",
         "strawberryfield/strawberryfield":"1.0.0.x-dev",
         "strawberryfield/webform_strawberryfield":"1.0.0.x-dev",
         "strawberryfield/format_strawberryfield":"1.0.0.x-dev",


### PR DESCRIPTION
See #124 

This fixes max version of VBO to 4.1.2 until we release 0.6.0 with changed signatures and we target 4.1.5 (4.1.4 and 4.1.3 are buggy)

