### PR TITLE
ISSUE-124: VBO breaks after 4.1.2. Update composer.json in 0.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/core": "^8.9 || ^9",
         "ext-zip": "*",
         "ext-json": "*",
-        "drupal/views_bulk_operations": "^3.9 || ^4.1",
+        "drupal/views_bulk_operations": "^3.9 || 4.1.2",
         "strawberryfield/strawberryfield":"1.0.0.x-dev",
         "strawberryfield/webform_strawberryfield":"1.0.0.x-dev",
         "strawberryfield/format_strawberryfield":"1.0.0.x-dev",


### PR DESCRIPTION
See #124 and https://github.com/esmero/ami/pull/125

@aksm same as before. Please merge as soon as you can?