### PR TITLE
ISSUE-129: Better remote Filename handling and small improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         }
     ],
     "require": {
-        "drupal/core": "^8.9 || ^9",
+        "drupal/core": "^9",
         "ext-zip": "*",
         "ext-json": "*",
-        "drupal/views_bulk_operations": "^3.9 || 4.1.2",
+        "drupal/views_bulk_operations": "4.1.2",
         "strawberryfield/strawberryfield":"1.0.0.x-dev",
         "strawberryfield/webform_strawberryfield":"1.0.0.x-dev",
         "strawberryfield/format_strawberryfield":"1.0.0.x-dev",

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -491,9 +491,8 @@ class AmiUtilityService {
       }
       $response = $this->httpClient->get($uri, ['sink' => $path, 'timeout' => round($max_time,2)]);
       $filename_from_remote = $basename;
-      $filename_from_remote_parts = explode(".", $basename, 2);
-      $filename_from_remote_without_extension = $filename_from_remote_parts[0] ?? NULL;
-      $extensions_from_remote = $filename_from_remote_parts[1] ?? NULL;
+      $filename_from_remote_without_extension = pathinfo($filename_from_remote, PATHINFO_FILENAME);
+      $extensions_from_remote = pathinfo($filename_from_remote, PATHINFO_EXTENSION);
       $extension_from_mime = NULL;
       $extension = NULL;
       $content_disposition = $response->getHeader('Content-Disposition');
@@ -503,11 +502,12 @@ class AmiUtilityService {
         if ($filename_from_remote) {
           // we want the name without extension, we do not trust the extension
           // See remote sources with double extension!
-          $filename_from_remote_parts = explode(".", $filename_from_remote, 2);
-          $filename_from_remote_without_extension = $filename_from_remote_parts[0] ?? NULL;
-          $extensions_from_remote = $filename_from_remote_parts[1] ?? NULL;
+          $filename_from_remote_without_extension = pathinfo($filename_from_remote, PATHINFO_FILENAME);
+          $extensions_from_remote = pathinfo($filename_from_remote, PATHINFO_EXTENSION);
         }
       }
+      $extensions_from_remote = !empty($extensions_from_remote) ? $extensions_from_remote :NULL;
+      $filename_from_remote_without_extension = !empty($filename_from_remote_without_extension) ? $filename_from_remote_without_extension :NULL;
     }
     catch (\Exception $exception) {
       $message_vars = [
@@ -697,6 +697,8 @@ class AmiUtilityService {
    */
   public function create_file_from_uri($localpath) {
     try {
+
+      /** @var File $file */
       $file = $this->entityTypeManager->getStorage('file')->create(
         [
           'uri' => $localpath,

--- a/src/Controller/AmiRowAutocompleteHandler.php
+++ b/src/Controller/AmiRowAutocompleteHandler.php
@@ -298,13 +298,18 @@ class AmiRowAutocompleteHandler extends ControllerBase {
               switch ($mimetype) {
                 case 'application/ld+json':
                 case 'application/json':
-                  json_decode((string) $render);
+                  $json_decoded = json_decode((string) $render);
                   if (JSON_ERROR_NONE !== json_last_error()) {
                     throw new \Exception(
                       'Error parsing JSON: ' . json_last_error_msg(),
                       0,
                       NULL
                     );
+                  }
+                  else {
+                    // If the test passed show it pretty printed so Allison
+                    // has a better experience.
+                    $render = json_encode($json_decoded, JSON_PRETTY_PRINT);
                   }
                   break;
                 case 'text/html':

--- a/src/Form/amiSetEntityDeleteProcessedForm.php
+++ b/src/Form/amiSetEntityDeleteProcessedForm.php
@@ -63,7 +63,7 @@ class amiSetEntityDeleteProcessedForm extends ContentEntityConfirmFormBase {
    * {@inheritdoc}
    */
   public function getCancelUrl() {
-    return new Url('entity.ami_set_entity.collection');
+    return new Url('entity.ami_set_entity.process_form',['ami_set_entity' => $this->entity->id()]);
   }
 
 

--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -962,6 +962,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
     // at this level makes no sense. Safer to regenerate.
     $zip_file_id = is_object($data->info['zip_file']) && $data->info['zip_file'] instanceof FileInterface ? (string) $data->info['zip_file']->id() : '0';
     $private_temp_key = md5(($data->info['file_column'] ?? '') . '-' . ($data->info['filename'] ?? '') . '-' . $zip_file_id);
+
     $processed_file_data = $this->store->get('set_' . $data->info['set_id'] . '-' . $private_temp_key);
     // even if the cache is there, the file might have been gone because of a previous cron
     // run after someone deleted the Ingested, waited too long.
@@ -998,6 +999,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
             $force_destination,
             $reduced
           );
+
         $data_to_store['as_data'] = $processedAsValuesForKey;
         $data_to_store['file_id'] = $file->id();
         $this->store->set('set_' . $data->info['set_id'] . '-' . $private_temp_key,


### PR DESCRIPTION
See #129 
This also adds:
- JSON Pretty printing to AMI Set previews that generate (of course) JSON when the "use destination format" check is enabled
- Redirects user to "process" tab after running a "delete processed"
@aksm could you give this a small look?