### PR TITLE
ISSUE-131: Fix wrong logic. Status might not be preset (yet)

### DIFF
--- a/src/Form/amiSetEntityReportForm.php
+++ b/src/Form/amiSetEntityReportForm.php
@@ -139,7 +139,8 @@ class amiSetEntityReportForm extends ContentEntityConfirmFormBase {
     /* Fetch the status from the private store also: */
     $store = \Drupal::service('tempstore.private')->get('ami_queue_status');
     $last_status = $store->get('set_'.$this->entity->id());
-
+    // $last_status needs to be countable always
+    $last_status = $last_status ?? [];
 
     foreach ($this->entity->get('set') as $item) {
       /** @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $item */


### PR DESCRIPTION
See #131 

This fixes a white screen/exception when accessing existing reports (generated e.g via a previous hash of 0.5.0) but without yet a status report generated from a Batch Processing. My bad.

