### PR TITLE
ISSUE-136: Adds '#description_display' => 'before' to avoid warning

### DIFF
--- a/src/Controller/AmiRowAutocompleteHandler.php
+++ b/src/Controller/AmiRowAutocompleteHandler.php
@@ -278,6 +278,7 @@ class AmiRowAutocompleteHandler extends ControllerBase {
             '#type' => 'codemirror',
             '#title' => t('Original JSON of an ADO <b>{{ dataOriginal.keyname }}</b> :'),
             '#description' => t('This data structure will contain the original values (before modification) of an ADO only when updating. Sadly we can not at this time preview it during an AMI set preview.'),
+            '#description_display' => 'before',
             '#rows' => 60,
             '#value' => json_encode('{}', JSON_PRETTY_PRINT),
             '#codemirror' => [

--- a/src/Controller/AmiRowAutocompleteHandler.php
+++ b/src/Controller/AmiRowAutocompleteHandler.php
@@ -247,6 +247,7 @@ class AmiRowAutocompleteHandler extends ControllerBase {
           $output['json'] = [
             '#type' => 'details',
             '#title' => t('JSON Data'),
+            '#description_display' => 'before',
             '#open' => FALSE,
           ];
           $output['json']['data'] = [
@@ -366,6 +367,7 @@ class AmiRowAutocompleteHandler extends ControllerBase {
                 '#type' => 'details',
                 '#open' => TRUE,
                 '#title' => 'HTML Output',
+                '#description_display' => 'before',
                 'messages' => [
                   '#markup' => $message,
                   '#attributes' => [
@@ -388,6 +390,7 @@ class AmiRowAutocompleteHandler extends ControllerBase {
             $output['preview'] = [
               '#type' => 'details',
               '#open' => TRUE,
+              '#description_display' => 'before',
               '#title' => t('Syntax error'),
               'error' => [
                 '#markup' => $message,
@@ -401,6 +404,7 @@ class AmiRowAutocompleteHandler extends ControllerBase {
           $output['preview'] = [
             '#type' => 'details',
             '#open' => TRUE,
+            '#description_display' => 'before',
             '#title' => !$file ? t('AMI Set has no CSV File'): t('AMI Set has no data for chosen row.'),
             'error' => [
               '#markup' => t('The AMI set is empty.'),


### PR DESCRIPTION
See #136 

We are not even using #description but seems like #description_display IS required. Will test more