### PR TITLE
ISSUE-159: Remove spaces and dots from the beginning in any combination for remote filenames

### DIFF
--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -515,7 +515,8 @@ class AmiUtilityService {
       $filename_from_remote_without_extension = !empty($filename_from_remote_without_extension) ? $filename_from_remote_without_extension :NULL;
       // remove any leading dots from here. The original Path (because it is calculated based on the URL) will not contain these
       if ($filename_from_remote_without_extension) {
-        // remove any spaces from the start and end$filename_from_remote_without_extension = trim($filename_from_remote_without_extension);
+        // remove any spaces from the start and end
+        $filename_from_remote_without_extension = trim($filename_from_remote_without_extension);
         // now remove and leading dots + spaces that might come after the dots
         $filename_from_remote_without_extension = preg_replace('/^(\.|\h)*/m', '', $filename_from_remote_without_extension);
         // if the regular expression fails OR the filename was just dots (like i have seen it all - the song -) use the original sink path

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -511,8 +511,8 @@ class AmiUtilityService {
           $extensions_from_remote = pathinfo($filename_from_remote, PATHINFO_EXTENSION);
         }
       }
-      $extensions_from_remote = !empty($extensions_from_remote) ? $extensions_from_remote :NULL;
-      $filename_from_remote_without_extension = !empty($filename_from_remote_without_extension) ? $filename_from_remote_without_extension :NULL;
+      $extensions_from_remote = !empty($extensions_from_remote) ? $extensions_from_remote : NULL;
+      $filename_from_remote_without_extension = !empty($filename_from_remote_without_extension) ? $filename_from_remote_without_extension : NULL;
       // remove any leading dots from here. The original Path (because it is calculated based on the URL) will not contain these
       if ($filename_from_remote_without_extension) {
         // remove any spaces from the start and end
@@ -521,7 +521,7 @@ class AmiUtilityService {
         $filename_from_remote_without_extension = preg_replace('/^(\.|\h)*/m', '', $filename_from_remote_without_extension);
         // if the regular expression fails OR the filename was just dots (like i have seen it all - the song -) use the original sink path
         $filename_from_remote_without_extension = !empty($filename_from_remote_without_extension)
-        && strlen($filename_from_remote_without_extension) > 0  ? $filename_from_remote_without_extension :NULL;
+        && (strlen($filename_from_remote_without_extension) > 0) ? $filename_from_remote_without_extension : NULL;
       }
     }
     catch (\Exception $exception) {

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -513,6 +513,15 @@ class AmiUtilityService {
       }
       $extensions_from_remote = !empty($extensions_from_remote) ? $extensions_from_remote :NULL;
       $filename_from_remote_without_extension = !empty($filename_from_remote_without_extension) ? $filename_from_remote_without_extension :NULL;
+      // remove any leading dots from here. The original Path (because it is calculated based on the URL) will not contain these
+      if ($filename_from_remote_without_extension) {
+        // remove any spaces from the start and end$filename_from_remote_without_extension = trim($filename_from_remote_without_extension);
+        // now remove and leading dots + spaces that might come after the dots
+        $filename_from_remote_without_extension = preg_replace('/^(\.|\h)*/m', '', $filename_from_remote_without_extension);
+        // if the regular expression fails OR the filename was just dots (like i have seen it all - the song -) use the original sink path
+        $filename_from_remote_without_extension = !empty($filename_from_remote_without_extension)
+        && strlen($filename_from_remote_without_extension) > 0  ? $filename_from_remote_without_extension :NULL;
+      }
     }
     catch (\Exception $exception) {
       $message_vars = [


### PR DESCRIPTION
See #159 
This is a simple regular expression: `'/^(\.|\h)*/m'` It will match any combination of `dots` and horizontal spaces from the beginning. To be extra safe, after cleaning we check if anything is left and if not we actually default the the URL given name...

I only do this for Names provided by a header/remove HTTP idea. If a user decides to use local filenames or S3 ones, we don't want to modify their names at all (like really) and again, good practices are not something we SHOULD enforce via code. This is a way of getting around the strange filenames we are getting from remote sources.

Relates to https://github.com/esmero/strawberryfield/pull/266 which deals with actual filenames that have dots