### PR TITLE
ISSUE-177: of long Views and Display Machine names. 

### DIFF
--- a/src/EventSubscriber/AmiFacetsViewsBulkOperationsEventSubscriber.php
+++ b/src/EventSubscriber/AmiFacetsViewsBulkOperationsEventSubscriber.php
@@ -76,7 +76,7 @@ class AmiFacetsViewsBulkOperationsEventSubscriber implements EventSubscriberInte
   public function updateFacetCache(ViewsBulkOperationsEvent $event) {
     $view_data = $event->getViewData();
     $exposed_input = $event->getView()->getExposedInput();
-    $tempStoreName = 'ami_vbo_batch_facets_' . $event->getView()->id() . '_' . $event->getView()->current_display;
+    $tempStoreName = 'ami_vbo_batch_facets_' . md5($event->getView()->id() . '_' . $event->getView()->current_display);
     // Do not override once the batch starts.
     // Maybe delete when on view.solr_search_content_with_find_and_replace.page_1?
     // We do not know here if facets will or not be in a f[] so we pass

--- a/src/Plugin/Action/AmiStrawberryfieldCSVexport.php
+++ b/src/Plugin/Action/AmiStrawberryfieldCSVexport.php
@@ -549,10 +549,12 @@ class AmiStrawberryfieldCSVexport extends ConfigurableActionBase implements Depe
    *   Cache unique ID for Temporary storage.
    */
   protected function getCid() {
+    // a CID can only short. We take all the pieces and apply an MD5, 32Hex max.
     if (!isset($this->context['sandbox']['cid_prefix'])) {
-      $this->context['sandbox']['cid_prefix'] = $this->context['view_id'] . ':'
-        . $this->context['display_id'] . ':' . $this->context['action_id'] . ':'
-        . md5(serialize(array_keys($this->context['list']))) . ':';
+      $this->context['sandbox']['cid_prefix'] = md5(
+          $this->context['view_id'] . ':'
+          . $this->context['display_id'] . ':' . $this->context['action_id']
+         . serialize(array_keys($this->context['list']))) . ':';
     }
 
     return $this->context['sandbox']['cid_prefix'] . $this->context['sandbox']['current_batch'];

--- a/src/Plugin/facets/processor/VboBatchProcessorHandler.php
+++ b/src/Plugin/facets/processor/VboBatchProcessorHandler.php
@@ -183,7 +183,7 @@ class VboBatchProcessorHandler extends ProcessorPluginBase implements BuildProce
       $request,
       $container->get('tempstore.private'),
       $container->get('current_user'),
-      $container->get('entity_type.manager'),
+      $container->get('entity_type.manager')
     );
   }
 
@@ -242,7 +242,9 @@ class VboBatchProcessorHandler extends ProcessorPluginBase implements BuildProce
     $view_id = $fs_id[2];
     $display_id = $fs_id[3];
     $url_parameters = $this->request->query;
-    $tempStoreName = 'ami_vbo_batch_facets_' . $view_id . '_' . $display_id;
+    // If this is too long we will get a Data too long for column 'collection' at
+    // DatabaseExceptionWrapper. So we md5 all.
+    $tempStoreName = 'ami_vbo_batch_facets_' . md5($view_id . '_' . $display_id);
     // Get the active facet parameters.
     $active_params = NULL;
     $views_params = $this->tempStoreFactory->get($tempStoreName)->get($this->currentUser->id());


### PR DESCRIPTION
See #177 

This solves our part of the issue but, sadly, as I explored the world of non-sense, long Machine names (creating the longest Drupal allowed me to) I broke VBO.

See this here https://git.drupalcode.org/project/views_bulk_operations/-/blob/4.2.x/src/ViewsBulkOperationsBatch.php#L76
Basically VBO does the same, concatenates this blindly, breaking when the sum of a Views Machine name + a Display exceeds the very tiny Drupal Name for a temporary storage collection...

@alliomeria @aksm the world of OSS is hard.