### PR TITLE
ISSUE-190: Set max-age to 0 for amiSetEntityReportForm.php

### DIFF
--- a/src/Form/amiSetEntityReportForm.php
+++ b/src/Form/amiSetEntityReportForm.php
@@ -380,6 +380,12 @@ class amiSetEntityReportForm extends ContentEntityConfirmFormBase {
       '#type' => 'submit',
       '#value' => $this->t('Submit'),
     );
+    // Because this form has no real submissions and the entity itself is not changing
+    // we had users seen stale (no reports) but other user loging in can see them
+    // Maybe this helps?
+    $form['#cache'] = [
+      'max-age' => 0
+    ];
     return $form + parent::buildForm($form, $form_state);
   }
 


### PR DESCRIPTION
See #190 

Adds a 'max-age' 0 to the #cache entry in the Reports form