### PR TITLE
ISSUE-197: Deals with moving target for our VBO Event subscriber conditionals

### DIFF
--- a/src/EventSubscriber/AmiFacetsViewsBulkOperationsEventSubscriber.php
+++ b/src/EventSubscriber/AmiFacetsViewsBulkOperationsEventSubscriber.php
@@ -78,18 +78,21 @@ class AmiFacetsViewsBulkOperationsEventSubscriber implements EventSubscriberInte
     $exposed_input = $event->getView()->getExposedInput();
     $tempStoreName = 'ami_vbo_batch_facets_' . md5($event->getView()->id() . '_' . $event->getView()->current_display);
     // Do not override once the batch starts.
-    // Maybe delete when on view.solr_search_content_with_find_and_replace.page_1?
     // We do not know here if facets will or not be in a f[] so we pass
-    // all. The processor will know/read from the URL Processor settings.
-    // Do not overridewrite once the batch starts. Arguments will be 'op' = 'do', _format = 'json', id = a number the batch id
+    // all values (also good, respects filters).
+    // The VBO URL facet processor will know/read from the URL Processor settings.
+    // Do not overridewrite once the batch starts or we will end with 0 filters.
+    // Arguments will be 'op' = 'do', _format = 'json', id = a number the batch id
     // Normally just checking if this is happening under the unbrella of the actual Views Route is enough
     // BUT ... we need to also take in account layout builder .. so in that case we check for 'op' !== do && id (the batch)
-    // Just in case.
     // @TODO. No idea how to deal with the blocks and other options
     // I could to the opposite> Save it anytime it is not a batch but bc Facets are basically processed all the time
     // anywhere that would be a lot of extra processing time.
     if ((\Drupal::routeMatch()->getRouteName() == 'view'. '.' . $event->getView()->id(). '.' .$event->getView()->current_display) ||
-      \Drupal::routeMatch()->getRouteObject()->getOption('_layout_builder') && $exposed_input['op']!== "do" && !isset($exposed_input['id'])) {
+      (
+        (\Drupal::routeMatch()->getRouteObject()->getOption('_layout_builder') ||
+          $event->getView()->display_handler->getBaseId() == 'block') && (($exposed_input['op'] ?? NULL) !== "do") && !isset($exposed_input['id']))
+    ) {
       $this->tempStoreFactory->get($tempStoreName)->set(
         $this->currentUser->id(), $exposed_input ?? []
       );

--- a/src/EventSubscriber/AmiFacetsViewsBulkOperationsEventSubscriber.php
+++ b/src/EventSubscriber/AmiFacetsViewsBulkOperationsEventSubscriber.php
@@ -81,8 +81,15 @@ class AmiFacetsViewsBulkOperationsEventSubscriber implements EventSubscriberInte
     // Maybe delete when on view.solr_search_content_with_find_and_replace.page_1?
     // We do not know here if facets will or not be in a f[] so we pass
     // all. The processor will know/read from the URL Processor settings.
-    // Do not overridewrite once the batch starts. Arguments will be 'op', format, id
-    if (!isset($exposed_input['op'])) {
+    // Do not overridewrite once the batch starts. Arguments will be 'op' = 'do', _format = 'json', id = a number the batch id
+    // Normally just checking if this is happening under the unbrella of the actual Views Route is enough
+    // BUT ... we need to also take in account layout builder .. so in that case we check for 'op' !== do && id (the batch)
+    // Just in case.
+    // @TODO. No idea how to deal with the blocks and other options
+    // I could to the opposite> Save it anytime it is not a batch but bc Facets are basically processed all the time
+    // anywhere that would be a lot of extra processing time.
+    if ((\Drupal::routeMatch()->getRouteName() == 'view'. '.' . $event->getView()->id(). '.' .$event->getView()->current_display) ||
+      \Drupal::routeMatch()->getRouteObject()->getOption('_layout_builder') && $exposed_input['op']!== "do" && !isset($exposed_input['id'])) {
       $this->tempStoreFactory->get($tempStoreName)->set(
         $this->currentUser->id(), $exposed_input ?? []
       );


### PR DESCRIPTION
See #197 

Since Drupal 10.2 we can't no longer just relay on a 'op' in the input to avoid saving in our VBO temporary storage facets and filters. 

This new approach here attempts first to check if the `VBO` operation is happening under the actual Views `ROUTE` (so the page that the views handles) OR, if someone is using layout builder/a block, if 'op' != 'do' (might be another moving target) and there is no batch id.

How I covered VBO with facets running as a block is probably not the cleanest way but for now is solid enough

@davidbasswwu @alliomeria will ping you when the block option is tested and all is merged

