### PR TITLE
ISSUE-221: Drupal 10.2.8+ throws error on Array render 

### DIFF
--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -2458,12 +2458,28 @@ class AmiUtilityService {
       $cacheabledata = [];
       // @see https://www.drupal.org/node/2638686 to understand
       // What cacheable, Bubbleable metadata and early rendering means.
-      $cacheabledata = \Drupal::service('renderer')->executeInRenderContext(
-        new RenderContext(),
-        function () use ($context, $metadatadisplay_entity) {
-          return $metadatadisplay_entity->renderNative($context);
-        }
-      );
+      try {
+        $cacheabledata = \Drupal::service('renderer')->executeInRenderContext(
+          new RenderContext(),
+          function () use ($context, $metadatadisplay_entity) {
+            return $metadatadisplay_entity->renderNative($context);
+          }
+        );
+      }
+      catch (\Exception $error) {
+          $message = $this->t(
+            'Twig could not render the Metadata Display ID @metadatadisplayid for AMI Set ID @setid, with Row @row, future ADO with UUID @uuid. The Twig Rendered error is %output. Please check your template against that row data and make sure you are handling values, arrays and filters correctly.',
+            [
+              '@metadatadisplayid' => $metadatadisplay_id,
+              '@uuid' => $data->info['row']['uuid'],
+              '@row' => $row_id,
+              '@setid' => $set_id,
+              '%output' => $error->getMessage(),
+            ]
+          );
+          $this->loggerFactory->get('ami')->error($message);
+          return NULL;
+      }
       if (count($cacheabledata)) {
         $jsonstring = $cacheabledata->__toString();
         $jsondata = json_decode($jsonstring, TRUE);

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -2468,7 +2468,7 @@ class AmiUtilityService {
       }
       catch (\Exception $error) {
           $message = $this->t(
-            'Twig could not render the Metadata Display ID @metadatadisplayid for AMI Set ID @setid, with Row @row, future ADO with UUID @uuid. The Twig Rendered error is %output. Please check your template against that row data and make sure you are handling values, arrays and filters correctly.',
+            'Twig could not render the Metadata Display ID @metadatadisplayid for AMI Set ID @setid, with Row @row, future ADO with UUID @uuid. The Twig internal renderer error is: %output. Please check your template against that AMI row and make sure you are handling values, arrays and filters correctly.',
             [
               '@metadatadisplayid' => $metadatadisplay_id,
               '@uuid' => $data->info['row']['uuid'],


### PR DESCRIPTION
(was User one before.. which is really a warning)

This wraps just around AMI Metadata Display processing a catch/try and logs an error. Will handle it returning NULL the same way it would do for improper JSON or invalid template (non existing)

@patdunlavey now your job is to properly test this against the same data/metadata combo you had failed/re-enqueuing forever and let me know if this needs more changes.

I would love to do that here really \Drupal\format_strawberryfield\Entity\MetadataDisplayEntity::renderNative at the source itself .. BUT ... we would not be able to run Metadata Display previews at all if I did that..

I will work on a refactor of the base methods and will try an override of the new Drupal Default Twig HTML filter that is where this whole mess started