### PR TITLE
ISSUE-236: Unmoderated Status improvements/bug fixes and new "Sync/Update" option

### DIFF
--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -1915,6 +1915,9 @@ class AmiUtilityService {
     $account = $uid == \Drupal::currentUser()->id() ? \Drupal::currentUser() : $this->entityTypeManager->getStorage('user')->load($uid);
 
     $file_data_all = $this->csv_read($file);
+    if (!$file_data_all) {
+      return [];
+    }
     // We want to validate here if the found Headers match at least the
     // Mapped ones during AMI setup. If not we will return an empty array
     // And send a Message to the user.

--- a/src/Form/amiSetEntityDeleteProcessedForm.php
+++ b/src/Form/amiSetEntityDeleteProcessedForm.php
@@ -207,7 +207,7 @@ class amiSetEntityDeleteProcessedForm extends ContentEntityConfirmFormBase {
       $form['delete_enqueued'] = [
         '#type' => 'fieldset',
         '#title' => $this->t('Delete Ingested ADOs via this Set'),
-        '#description' => $this->t('Confirming will trigger a Batch Delete for already ingested ADOs you have permission to delete.'),
+        '#description' => $this->t('Confirming will trigger an Enqueued Batch Delete (not real time) for already ingested ADOs you have permission to delete.'),
       ];
     }
     return $form + parent::buildForm($form, $form_state);

--- a/src/Form/amiSetEntityProcessForm.php
+++ b/src/Form/amiSetEntityProcessForm.php
@@ -92,6 +92,16 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
     $ops_skip_onmissing_file = (bool) $form_state->getValue('skip_onmissing_file', TRUE);
     $ops_forcemanaged_destination_file = (bool) $form_state->getValue('take_control_file', TRUE);
 
+    // Normalize Un Moderadet Statuses if 0 and 1
+    foreach ($statuses as $bundle => &$value) {
+      if ($value == "1") {
+        $value = 1;
+      }
+      elseif ($value == "0") {
+        $value = 0;
+      }
+    }
+
     $csv_file_reference = $this->entity->get('source_data')->getValue();
     if (isset($csv_file_reference[0]['target_id'])) {
       /** @var \Drupal\file\Entity\File $file */
@@ -439,7 +449,7 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
             '#disabled' => TRUE,
             '#title' => $this->t('Update Operation'),
             '#description' => $this->t(
-              'Please review the <a href="https://docs.archipelago.nyc/1.4.0/ami_update/">AMI Update Sets Documentation</a> before proceeding, and consider first testing your planned updates against a single row/object CSV before executing updates across a larger batch of objects. There is no "undo" operation for AMI Update Sets.'),
+              'Please review the <a href="https://docs.archipelago.nyc/1.5.0/ami_update/">AMI Update Sets Documentation</a> before proceeding, and consider first testing your planned updates against a single row/object CSV before executing updates across a larger batch of objects. There is no "undo" operation for AMI Update Sets.'),
             '#options' => $ops_update_sync,
             '#default_value' => 'update',
             '#wrapper_attributes' => [
@@ -494,11 +504,11 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
           '#tree' => TRUE,
           '#type' => 'checkbox',
           '#title' => $this->t(
-            'Do not modify ADOs Status at all.'
+            'Do not modify ADOs Status.'
           ),
           '#weigth' => 100,
           '#description' => $this->t(
-            'If checked, "Desired ADOs Statuses will have no effect on existing ADOs.". Use this if you have manually unpublished/published ADOs that are part of this AMI set before and you want to presenve those decisions.'
+            'If checked, "Desired ADOs statuses" will be ignored, effectively preserving the already ingested ADOs status.'
           ),
           '#parents' => ['status_keep'],
           '#required' => FALSE,
@@ -507,7 +517,10 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
       }
       if ($op == 'sync') {
         $form['status']['status_keep']['#title'] = $this->t(
-          'Do not modify ADOs Status of already existing ADOs, but Newly created ones via this AMI set will get your chosen status.'
+          'Do not modify the Status of already existing ADOs.'
+        );
+        $form['status']['status_keep']['#description'] = $this->t(
+          'If checked, Only newly created ADOs will have the chosen status applied.'
         );
       }
 
@@ -646,7 +659,7 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
     if (empty($element)) {
       $element =  [
         '#type' => 'container',
-        'state' => [
+        $bundle  => [
           '#type' => 'select',
           '#title' => $this->t('Status for @bundle', ['@bundle' => $bundle_label]),
           '#options' => [

--- a/src/Plugin/QueueWorker/CsvADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/CsvADOQueueWorker.php
@@ -142,11 +142,11 @@ class CsvADOQueueWorker extends IngestADOQueueWorker
           ];
           // Overrides in case we are in a sync operation.
           $valid_op = TRUE;
+          $skip = FALSE;
           if ($data->pluginconfig->op == 'sync') {
             // Important we will move the data driven (ami_sync_op) info the que info
             // structure secondary.
             // Fixed key:
-            $skip = FALSE;
             $sync_op = $item['data']['ami_sync_op'] ?? 'create';
               if ($sync_op === 'create') {
                 $adodata->info['op_secondary'] = 'create';

--- a/src/Plugin/QueueWorker/CsvADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/CsvADOQueueWorker.php
@@ -41,6 +41,7 @@ class CsvADOQueueWorker extends IngestADOQueueWorker
         'uid' => The User ID that processed the Set
         'set_url' => A direct URL to the set.
         'status' => Either a string (moderation state) or a 1/0 for published/unpublished if not moderated
+        'status_keep' => If the current status should be kept or not. Only applies to existing ADOs via either Update or Sync Ops.
         'op_secondary' => applies only to Update/Patch operations. Can be one of 'update','replace','append'
         'ops_safefiles' => Boolean, True if we will not allow files/mappings to be removed/we will keep them warm and safe
         'log_jsonpatch' => If for Update operations we will generate a single PER ADO Log with a full JSON Patch,
@@ -124,6 +125,7 @@ class CsvADOQueueWorker extends IngestADOQueueWorker
             'row' => $item,
             'set_id' => $data->info['set_id'],
             'uid' => $data->info['uid'],
+            'status_keep' => $data->info['status_keep'] ?? FALSE,
             'status' => $data->info['status'],
             'op_secondary' => $data->info['op_secondary'] ?? NULL,
             'ops_safefiles' => $data->info['ops_safefiles'] ? TRUE : FALSE,

--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -818,6 +818,13 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
     $field_name_offset = $property_path_split[2] ?? 0;
     // Fall back to not published in case no status was passed.
     $status = $data->info['status'][$bundle] ?? 0;
+    // This is tricky. String 1 v/s integer one
+    if ($status == "1") {
+      $status = 1;
+    }
+    if ($status == "0") {
+      $status = 0;
+    }
     $status_keep = $data->info['status_keep'] ?? FALSE;
     // default Sortfile which will respect the ingest order. If there was already one set, preserve.
     $sort_files = isset($processed_metadata['ap:tasks']) && isset($processed_metadata['ap:tasks']['ap:sortfiles']) ?  $processed_metadata['ap:tasks']['ap:sortfiles'] : 'index';

--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -269,6 +269,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
         'uid' => The User ID that processed the Set
         'set_url' => A direct URL to the set.
         'status' => Either a string (moderation state) or a 1/0 for published/unpublished if not moderated
+        'status_keep' => If the current status should be kept or not. Only applies to existing ADOs via either Update or Sync Ops.
         'op_secondary' => applies only to Update/Patch operations. Can be one of 'update','replace','append'
         'ops_safefiles' => Boolean, True if we will not allow files/mappings to be removed/we will keep them warm and safe
         'log_jsonpatch' => If for Update operations we will generate a single PER ADO Log with a full JSON Patch,
@@ -817,6 +818,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
     $field_name_offset = $property_path_split[2] ?? 0;
     // Fall back to not published in case no status was passed.
     $status = $data->info['status'][$bundle] ?? 0;
+    $status_keep = $data->info['status_keep'] ?? FALSE;
     // default Sortfile which will respect the ingest order. If there was already one set, preserve.
     $sort_files = isset($processed_metadata['ap:tasks']) && isset($processed_metadata['ap:tasks']['ap:sortfiles']) ?  $processed_metadata['ap:tasks']['ap:sortfiles'] : 'index';
     // We can't blindly override ap:tasks if we are dealing with an update operation. So make an exception here for only create
@@ -875,8 +877,8 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
 
           /** @var \Drupal\Core\Field\FieldItemInterface $field*/
           $field = $node->get($field_name);
-          // Ignore status for updates derived from sync ops.
-          if ($status && is_string($status) && $op_original !== 'sync') {
+          // Ignore status for updates if status_keep == TRUE.
+          if ($status && is_string($status) && $status_keep == FALSE) {
             $node->set('moderation_state', $status);
             $status = 0;
           }
@@ -1056,14 +1058,14 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
         }
         // In case $status was not moderated.
         if ($status) {
-          // We won't change status for sync op that generate an update
-          if (!($op_original == 'sync' && $op == 'update')) {
+          // Publish status keep is FALSE
+          if ($op == 'update' && $status_keep == FALSE) {
             $node->setPublished();
           }
         }
         elseif (!isset($nodeValues['moderation_state'])) {
-          // Only unpublish if not moderated and not a sync -> update chain.
-          if (!($op_original == 'sync' && $op == 'update')) {
+          // Only unpublish if not moderated and status keep is FALSE.
+          if ($op == 'update' && $status_keep == FALSE) {
             $node->setUnpublished();
           }
         }


### PR DESCRIPTION
See #236 

Also adds UUID V4 AMI set Step validation for EAD Sync and also some "wrong CSV/empty CSV" fall backs.

I have to be honest here: The AMI EAD SYNC plugin requires a very specific reality (Metadata/structure) and understanding that the actual "I will sync on the current state of the repo" happens once, during the AMI set setup. Any larger change on ADOs that happens after that, before the EAD Sync runs might lead to an inconsistent *or unexpected* result. Be aware of that. There is no way modifying/updating/deleting 10K objects in a pass can NOT be a "be careful/think/plan" operation.

Also solves the warning of non initialized variable $skip in the CSV expander