### PR TITLE
ISSUE-252: User variation does not permeate to Menu Local task (tabs) render cache when viewing an AMI set

### DIFF
--- a/ami.module
+++ b/ami.module
@@ -226,3 +226,21 @@ function ami_file_download($uri) {
     'Content-Disposition' => HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, (string) $filename),
   ];
 }
+/**
+ * Implements hook_menu_local_tasks_alter().
+ *
+ * Adds the user context to the $cacheability
+ *
+ */
+ function ami_menu_local_tasks_alter(&$data, $route_name, \Drupal\Core\Cache\RefinableCacheableDependencyInterface &$cacheability) {
+  // Something changed in Drupal 10.2+ and Local tabs (on AMI set entity view route)
+  // were stuck by "permission" context. Which implies, if a user had "op own ami set"
+  // permission, and a user not owning the AMI set, but sharing the same role //
+  // looked at the AMI set, from there on the owner itself would no longer see the tabs/
+  // and would get the cached (bc sharing the same role) menu.
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  if ($route_name !== 'entity.ami_set_entity.canonical') {
+    return;
+  }
+  $cacheability->addCacheContexts(['user']);
+}


### PR DESCRIPTION
This is one way of solving it, AMI set entities cache should not vary only by "Role" bc the fact that we have "some operation on own AMI set" permissions makes same role -> different behavior based on who sees the Object. That works well on the actual "access" but as explained in the comments of this hook leads to disappearing tabs (not the actual permission/access to the route) when two users sharing the same Role access one of those users owned AMI set. Another way would be to return even the "neutral" access responses (so the case when the not owner access it) with the "user" context ... will test tomorrow what the effect of that is. Weird is no core/contributed entity does that. @alliomeria i will need to evaluate if this also happens with Metadata Display entities on format strawberry field.

Caching here is really not a performance issue. One will never have 1 million AMI sets, nor 1 million Twig templates ... also this really looks like a Drupal 10.2++ or 10.3++ change, we never had that before and we are not the only ones reporting stuck Menu tasks (I even think we saw 2025 something like that, a "weird" edit button in one of our partners NODES @alliomeria ? maybe an IR repo?)