### PR TITLE
ISSUE-252: Add user cache context to AMI set Entity Task menu

### DIFF
--- a/ami.module
+++ b/ami.module
@@ -226,3 +226,21 @@ function ami_file_download($uri) {
     'Content-Disposition' => HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, (string) $filename),
   ];
 }
+/**
+ * Implements hook_menu_local_tasks_alter().
+ *
+ * Adds the user context to the $cacheability
+ *
+ */
+ function ami_menu_local_tasks_alter(&$data, $route_name, \Drupal\Core\Cache\RefinableCacheableDependencyInterface &$cacheability) {
+  // Something changed in Drupal 10.2+ and Local tabs (on AMI set entity view route)
+  // were stuck by "permission" context. Which implies, if a user had "op own ami set"
+  // permission, and a user not owning the AMI set, but sharing the same role //
+  // looked at the AMI set, from there on the owner itself would no longer see the tabs/
+  // and would get the cached (bc sharing the same role) menu.
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  if ($route_name !== 'entity.ami_set_entity.canonical') {
+    return;
+  }
+  $cacheability->addCacheContexts(['user']);
+}


### PR DESCRIPTION
See #252. This is the 1.0.0 (Drupal 10) version.

Note for anyone reading the code. There could be other ways of doing this? Like setting user as context always even if "not allowed" when returning from the Access manager @alliomeria but since we already know the permissions are working well (tested) I felt this one was a simpler one