### PR TITLE
ISSUE-267 & ISSUE-263: D11 - AMI Set (single Row) Simulation

### DIFF
--- a/ami.install
+++ b/ami.install
@@ -151,7 +151,7 @@ function ami_update_8905() {
     ->accessCheck(FALSE)
     ->execute();
 
-  // Load all the articles.
+  // Load all the AMI sets.
   $entities = \Drupal::entityTypeManager()->getStorage('ami_set_entity')->loadMultiple($entities_nids);
   foreach ($entities as $entity) {
     $entity->setStatus(amiSetEntity::STATUS_READY);
@@ -235,4 +235,36 @@ function ami_update_10161() {
     'weight' => -3,
   ]);
   \Drupal::entityDefinitionUpdateManager()->updateFieldStorageDefinition($field_storage_definition_zip_file);
+}
+/**
+ * Update ami_update_10171 - Checks for pre-update AMI set CSV escaping,
+ * If a CSV row attached to an AMI set that has escaped characters is found
+ * The AMI set is marked as needing a suggested Update process.
+ */
+function ami_update_10171() {
+  $run_time = \Drupal::time()->getRequestTime();
+  \Drupal::state()->set('ami_pre_csvrfc_update',$run_time);
+  // Update all AMI sets already with 'ready' use the new uppercase default
+  $entities_nids = \Drupal::entityQuery('ami_set_entity')
+    ->condition('changed',  \Drupal::time()->getRequestTime())
+    ->accessCheck(FALSE)
+    ->execute();
+
+  $entities = \Drupal::entityTypeManager()
+    ->getStorage('ami_set_entity')
+    ->loadMultiple($entities_nids);
+  foreach ($entities as $ami_set_entity) {
+    $csv_file_reference = $ami_set_entity->get('source_data')->getValue();
+    if (isset($csv_file_reference[0]['target_id'])) {
+      /** @var \Drupal\file\Entity\File $file */
+      $file = \Drupal::entityTypeManager() > getStorage('file')->load(
+          $csv_file_reference[0]['target_id']
+        );
+      $amiUtilityService = \Drupal::service('ami.utility');
+      // To avoid adding a new field, we will use the actual updated date
+      // as a check.
+      // $entity->set('changed', $run_time); //
+      $hasescaping = $amiUtilityService->csv_check_escaped($file);
+    }
+  }
 }

--- a/ami.install
+++ b/ami.install
@@ -242,29 +242,56 @@ function ami_update_10161() {
  * The AMI set is marked as needing a suggested Update process.
  */
 function ami_update_10171() {
-  $run_time = \Drupal::time()->getRequestTime();
-  \Drupal::state()->set('ami_pre_csvrfc_update',$run_time);
-  // Update all AMI sets already with 'ready' use the new uppercase default
+  $to_be_reviewed = [];
   $entities_nids = \Drupal::entityQuery('ami_set_entity')
     ->condition('changed',  \Drupal::time()->getRequestTime())
     ->accessCheck(FALSE)
     ->execute();
-
+  /** @var \Drupal\ami\Entity\amiSetEntity[] $entities */
   $entities = \Drupal::entityTypeManager()
     ->getStorage('ami_set_entity')
     ->loadMultiple($entities_nids);
   foreach ($entities as $ami_set_entity) {
+    // Check first source data
     $csv_file_reference = $ami_set_entity->get('source_data')->getValue();
     if (isset($csv_file_reference[0]['target_id'])) {
       /** @var \Drupal\file\Entity\File $file */
-      $file = \Drupal::entityTypeManager() > getStorage('file')->load(
+      $file = \Drupal::entityTypeManager()->getStorage('file')->load(
           $csv_file_reference[0]['target_id']
         );
       $amiUtilityService = \Drupal::service('ami.utility');
       // To avoid adding a new field, we will use the actual updated date
       // as a check.
-      // $entity->set('changed', $run_time); //
       $hasescaping = $amiUtilityService->csv_check_escaped($file);
+      if ($hasescaping) {
+        $to_be_reviewed[] = $ami_set_entity->id();
+        $ami_set_entity->setStatus(amiSetEntity::STATUS_NEEDS_REVIEW);
+      }
     }
+    // Also check Processed data (LoD reconciliation)
+    $csv_file_reference_processed = $ami_set_entity->get('processed_data')->getValue();
+    if (isset($csv_file_reference_processed[0]['target_id'])) {
+      /** @var \Drupal\file\Entity\File $file */
+      $file = \Drupal::entityTypeManager()->getStorage('file')->load(
+          $csv_file_reference_processed[0]['target_id']
+        );
+      $amiUtilityService = \Drupal::service('ami.utility');
+      // To avoid adding a new field, we will use the actual updated date
+      // as a check.
+      $hasescaping = $amiUtilityService->csv_check_escaped($file);
+      if ($hasescaping) {
+        $to_be_reviewed[] = $ami_set_entity->id();
+        $ami_set_entity->setStatus(amiSetEntity::STATUS_NEEDS_REVIEW);
+      }
+    }
+  }
+  if (!empty($to_be_reviewed)) {
+    $to_be_reviewed = array_unique($to_be_reviewed);
+    return t('Possible none-compliant, with RFC 4180, CSVs found in the following AMI set entities: @entities. All those wehre marked as "Needing Review", if you need to re-run them.',  [
+      '@entities' => implode(', ',$to_be_reviewed)
+    ]);
+  }
+  else {
+    return t('Good! All your AMI set entity\'s CSVs seem to be RFC 4180 compliant!');
   }
 }

--- a/ami.libraries.yml
+++ b/ami.libraries.yml
@@ -1,0 +1,10 @@
+ami_preview_helper:
+  version: 1.0
+  js:
+    js/ami_preview_helper.js: {minified: false}
+  css:
+    component:
+      css/ami_preview_helper.css: { }
+  dependencies:
+    - core/drupal
+    - core/once

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "phpoffice/phpspreadsheet": "^1.15.0",
         "maennchen/zipstream-php": "^1.2 || ^2.1",
         "drupal/google_api_client": "^3.2 || ^4.3",
+        "jfcherng/php-diff": "^7",
         "ramsey/uuid": "^4",
         "monolog/monolog": "^2.9",
         "ext-simplexml": "*",

--- a/css/ami_preview_helper.css
+++ b/css/ami_preview_helper.css
@@ -1,0 +1,122 @@
+.diff-wrapper.diff {
+  --tab-size: 4;
+  background: repeating-linear-gradient(-45deg, whitesmoke, whitesmoke 0.5em, #e8e8e8 0.5em, #e8e8e8 1em);
+  border-collapse: collapse;
+  border-spacing: 0;
+  border: 1px solid black;
+  color: black;
+  empty-cells: show;
+  font-family: monospace;
+  font-size: 13px;
+  width: 100%;
+  word-break: break-all;
+}
+.diff-wrapper.diff th {
+  font-weight: 700;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+}
+.diff-wrapper.diff td {
+  vertical-align: baseline;
+}
+.diff-wrapper.diff td,
+.diff-wrapper.diff th {
+  border-collapse: separate;
+  border: none;
+  padding: 1px 2px;
+  background: #fff;
+}
+.diff-wrapper.diff td:empty:after,
+.diff-wrapper.diff th:empty:after {
+  content: " ";
+  visibility: hidden;
+}
+.diff-wrapper.diff td a,
+.diff-wrapper.diff th a {
+  color: #000;
+  cursor: inherit;
+  pointer-events: none;
+}
+.diff-wrapper.diff thead th {
+  background: #a6a6a6;
+  border-bottom: 1px solid black;
+  padding: 4px;
+  text-align: left;
+}
+.diff-wrapper.diff tbody.skipped {
+  border-top: 1px solid black;
+}
+.diff-wrapper.diff tbody.skipped td,
+.diff-wrapper.diff tbody.skipped th {
+  display: none;
+}
+.diff-wrapper.diff tbody th {
+  background: #cccccc;
+  border-right: 1px solid black;
+  text-align: right;
+  vertical-align: top;
+  width: 4em;
+}
+.diff-wrapper.diff tbody th.sign {
+  background: #fff;
+  border-right: none;
+  padding: 1px 0;
+  text-align: center;
+  width: 1em;
+}
+.diff-wrapper.diff tbody th.sign.del {
+  background: #fbe1e1;
+}
+.diff-wrapper.diff tbody th.sign.ins {
+  background: #e1fbe1;
+}
+.diff-wrapper.diff.diff-html {
+  white-space: pre-wrap;
+  tab-size: var(--tab-size);
+}
+.diff-wrapper.diff.diff-html .ch {
+  line-height: 1em;
+  background-clip: border-box;
+  background-repeat: repeat-x;
+  background-position: left center;
+}
+.diff-wrapper.diff.diff-html .ch.sp {
+  background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="rgba%2860, 60, 60, 50%25%29"/%3E%3C/svg%3E');
+  background-size: 1ch 1.25em;
+}
+.diff-wrapper.diff.diff-html .ch.tab {
+  background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="rgba%2860, 60, 60, 50%25%29"/%3E%3C/svg%3E');
+  background-size: calc(var(--tab-size) * 1ch) 1.25em;
+  background-position: 2px center;
+}
+.diff-wrapper.diff.diff-html .change.change-eq .old,
+.diff-wrapper.diff.diff-html .change.change-eq .new {
+  background: #fff;
+}
+.diff-wrapper.diff.diff-html .change .old {
+  background: #fbe1e1;
+}
+.diff-wrapper.diff.diff-html .change .new {
+  background: #e1fbe1;
+}
+.diff-wrapper.diff.diff-html .change .rep {
+  background: #fef6d9;
+}
+.diff-wrapper.diff.diff-html .change .old.none,
+.diff-wrapper.diff.diff-html .change .new.none,
+.diff-wrapper.diff.diff-html .change .rep.none {
+  background: transparent;
+  cursor: not-allowed;
+}
+.diff-wrapper.diff.diff-html .change ins,
+.diff-wrapper.diff.diff-html .change del {
+  font-weight: bold;
+  text-decoration: none;
+}
+.diff-wrapper.diff.diff-html .change ins {
+  background: #94f094;
+}
+.diff-wrapper.diff.diff-html .change del {
+  background: #f09494;
+}

--- a/js/ami_preview_helper.js
+++ b/js/ami_preview_helper.js
@@ -1,0 +1,13 @@
+(function (Drupal, once) {
+
+  'use strict';
+  Drupal.behaviors.ami_preview_helper = {
+    attach: function(context) {
+      const elementsToAttach = once('ami_preview_helper', '#ami-preview-container-ado', context);
+      elementsToAttach.forEach(element => {
+        element.querySelectorAll('a').forEach(link => {
+          link.removeAttribute('href');
+        });
+      });
+    }};
+})(Drupal, once);

--- a/src/AmiLoDService.php
+++ b/src/AmiLoDService.php
@@ -571,29 +571,6 @@ class AmiLoDService {
     return $results_processed;
   }
 
-
-  /**
-   * Checks if a string is valid JSON
-   *
-   * @param $string
-   *
-   * @return bool
-   */
-  public function isJson($string) {
-    json_decode($string);
-    return json_last_error() === JSON_ERROR_NONE;
-  }
-
-  /**
-   * Helper function that negates ::isJson.
-   * @param $string
-   *
-   * @return bool
-   */
-  public function isNotJson($string) {
-    return !$this->isJson($string);
-  }
-
   public function getCustomLoDEndpoints($as_arguments = FALSE) {
     $active_plugins = [];
     /* @var $plugin_config_entities \Drupal\webform_strawberryfield\Entity\LoDendpointEntity[] */

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -2527,7 +2527,6 @@ class AmiUtilityService {
             $existing_object = $existing_objects && count($existing_objects) == 1 ? reset($existing_objects) : NULL;
             if (!$existing_object || !$existing_object->access($sync_op, $account)) {
               unset($ado);
-              $index = max($row_id - 2, 0 );
               $invalid = $invalid + [$index => $index];
             }
           }

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -2900,9 +2900,12 @@ class AmiUtilityService {
    */
   public function isJson($string) {
     try {
-      $decoded = json_decode($string, TRUE, 512,JSON_THROW_ON_ERROR);
+      $decoded = json_decode($string, TRUE, 512, JSON_THROW_ON_ERROR);
       if (is_array($decoded) ) {
         return TRUE;
+      }
+      else {
+        return FALSE;
       }
     }
     catch (\Throwable $e) {

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -1554,15 +1554,17 @@ class AmiUtilityService {
     $data = $this->csv_read($file);
     $column_keys = $data['headers'] ?? [];
     $alldifferent = [];
+    $alldifferent_json = [];
     foreach ($columns as $column) {
       $column_index = array_search($column, $column_keys);
       if ($column_index !== FALSE) {
+        // New for 1.7.0/2.1.0 We process both. Strings and JSON. More expensive
+        // but also more precise.
         $alldifferent[$column] = $this->getDifferentValuesfromColumnSplit($data,
           $column_index);
-        if (empty($alldifferent[$column])) {
-          $alldifferent[$column] = $this->getDifferentValuesfromColumnJSON($data,
+        $alldifferent_json[$column] = $this->getDifferentValuesfromColumnJSON($data,
             $column_index);
-        }
+        $alldifferent[$column] = array_unique(array_merge($alldifferent[$column],  $alldifferent_json[$column]));
       }
     }
     return $alldifferent;
@@ -2619,10 +2621,12 @@ class AmiUtilityService {
               $data_to_clean['data'][0] = [$context['data'][$source_column]];
               $labels = $this->getDifferentValuesfromColumnSplit($data_to_clean,
                 0);
-              if (empty($labels)) {
-                $labels = $this->getDifferentValuesfromColumnJSON($data_to_clean,
+              // New for 1.7.0/2.1.0 We process both. Strings and JSON. More expensive
+              // but also more precise. The Preview does the same now
+              $labels_json= $this->getDifferentValuesfromColumnJSON($data_to_clean,
                   0);
-              }
+              // WE merge both results and make them unique
+              $labels = array_unique(array_merge($labels, $labels_json));
               foreach ($labels as $label) {
                 $lod_for_label = $this->AmiLoDService->getKeyValuePerAmiSet($label, $set_id);
                 if (is_array($lod_for_label) && count($lod_for_label) > 0) {
@@ -2886,15 +2890,24 @@ class AmiUtilityService {
 
 
   /**
-   * Checks if a string is valid JSON
+   * Checks if a string is valid RFC JSON (object or array)
+   * Skips if its a valid JSON-y-fable native, like a pure string
+   * or a number
    *
    * @param $string
    *
    * @return bool
    */
   public function isJson($string) {
-    json_decode($string);
-    return json_last_error() === JSON_ERROR_NONE;
+    try {
+      $decoded = json_decode($string, TRUE, 512,JSON_THROW_ON_ERROR);
+      if (is_array($decoded) ) {
+        return TRUE;
+      }
+    }
+    catch (\Throwable $e) {
+      return FALSE;
+    }
   }
 
   /**

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -661,9 +661,9 @@ class AmiUtilityService {
    * @param \Drupal\file\Entity\File $zip_file
    *     A Zip file with that may contain the $uri
    *
-   * @return mixed
+   * @return false|string
    *   One of these possibilities:
-   *   - If it succeeds an managed file object
+   *   - If it succeeds a Path to a managed file object
    *   - If it fails or NULL, FALSE.
    */
   public function retrieve_fromzip_file($uri, $destination = NULL, $replace = FileExists::Rename, File $zip_file = NULL) {
@@ -1563,7 +1563,7 @@ class AmiUtilityService {
         $alldifferent[$column] = $this->getDifferentValuesfromColumnSplit($data,
           $column_index);
         $alldifferent_json[$column] = $this->getDifferentValuesfromColumnJSON($data,
-            $column_index);
+          $column_index);
         $alldifferent[$column] = array_unique(array_merge($alldifferent[$column],  $alldifferent_json[$column]));
       }
     }
@@ -2624,7 +2624,7 @@ class AmiUtilityService {
               // New for 1.7.0/2.1.0 We process both. Strings and JSON. More expensive
               // but also more precise. The Preview does the same now
               $labels_json= $this->getDifferentValuesfromColumnJSON($data_to_clean,
-                  0);
+                0);
               // WE merge both results and make them unique
               $labels = array_unique(array_merge($labels, $labels_json));
               foreach ($labels as $label) {
@@ -2998,4 +2998,85 @@ class AmiUtilityService {
     \Drupal::cache()->invalidate($cache_id);
   }
 
+  /**
+   * Checks if a CSV has escaped special characters
+   *
+   * Old PHP defaults used "\" as escaping mechanis
+   * Which can break amongst other JSON encoded ROWS
+   * Starting with AMI 1.1.0 and 2.1.0 we read/write CSV unescaped
+   * following RFC 4180 to ensure a safe round trip and also
+   * Excel and Google Sheets editing and export compatibility
+   *
+   * @param \Drupal\file\Entity\File $file
+   *
+   * @return bool
+   *    TRUE means it has escaping or some other sanity issue
+   *    FALSE means all is good
+   */
+  public function csv_check_escaped(File $file): bool {
+    $needs_review = FALSE;
+    $wrapper = $this->streamWrapperManager->getViaUri($file->getFileUri());
+    if (!$wrapper) {
+      return FALSE;
+    }
+    $url = $wrapper->getUri();
+    $fh = new \SplFileObject($url, 'r');
+    if (!$fh) {
+      $this->messenger()->addError(
+        $this->t('Error reading the CSV file!.')
+      );
+      return FALSE;
+    }
+    // Instead or using PHP's CSV read line, we will get the complete lines first
+    // Then decode and apply a temporary fix to output unescaped.
+    // We compare the original read with the unescaped generation using md5
+    // ,and we also compare that each ROW has exactly the same columns
+    // as the header.
+    // In this case, since we are only checking, we bail out on the first encountered
+    // abnormality. Of course if all is OK we have to still iterate over all of them
+    $i = 0;
+    $header_count = FALSE;
+    while (!$fh->eof()) {
+      if ($i == 0) {
+        // Read the header unescaped. We do not support headers with double quotes
+        $header = $fh->fgetcsv(',', '"', "");
+        $header_count = is_array($header) ? count($header) : FALSE;
+        $needs_review = !($header_count);
+        $i++;
+      }
+      elseif ($header_count) {
+        $row_string = $fh->fgets();
+        if (!empty($row_string)) {
+          $row_unescaped = str_getcsv($row_string, ',', '"', "");
+          // Try replacing \" with \""
+          // but only if:
+          // - not before a comma.
+          // - 2 x double quote.
+          // - or a double quote followed by a space.
+          $pattern = '}\\\\"(?!(,|""|"\s))}';
+          $replacement = '\""';
+          $row_string_replaced = preg_replace($pattern, $replacement, $row_string);
+          $row_unescaped_after_replace = str_getcsv($row_string_replaced, ',', '"', "");
+          if (count($row_unescaped_after_replace) != $header_count) {
+            $needs_review = TRUE;
+            break;
+          }
+          if (md5(implode(";", $row_unescaped)) != md5(implode(";", $row_unescaped_after_replace))) {
+            $needs_review = TRUE;
+            break;
+          }
+          else {
+            $needs_review = FALSE;
+          }
+        }
+      }
+      else {
+        // $header_count is FALSE, means the CSV is malformed.
+        $needs_review = TRUE;
+      }
+    }
+    // Closes the SPL File Object.
+    $fh = NULL;
+    return $needs_review;
+  }
 }

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -1088,7 +1088,6 @@ class AmiUtilityService {
     return $file->id();
   }
 
-
   /**
    * Creates an CSV from array and returns file.
    *
@@ -1102,11 +1101,14 @@ class AmiUtilityService {
    * @param boolean $auto_uuid
    *    Defines if we are going to generate UUIDs when not valid/not present
    *    Or leave the $uuid_key field as it is and let this fail/if later.
+   * @param bool $permanent
+   * @param bool $escape_character
+   *    If used, CSV might not end being RFC 4180 compliant.
+   * @param string $logger_channel
    *
    * @return int|string|null
-   * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  public function csv_save(array $data, $uuid_key = 'node_uuid', $auto_uuid = TRUE, $permanent = TRUE, $logger_channel = 'ami') {
+  public function csv_save(array $data, $uuid_key = 'node_uuid', $auto_uuid = TRUE, $permanent = TRUE, bool $escape_character = FALSE, $logger_channel = 'ami') {
 
     //$temporary_directory = $this->fileSystem->getTempDirectory();
     // We should be allowing downloads for this from temp
@@ -1160,9 +1162,12 @@ class AmiUtilityService {
     if ($haskey === FALSE) {
       array_unshift($data['headers'], $uuid_key);
     }
-
-    $fh->fputcsv($data['headers']);
-
+    if ($escape_character) {
+      $fh->fputcsv($data['headers'],   separator: ',', enclosure: '"', escape: "\\");
+    }
+    else {
+      $fh->fputcsv($data['headers'], separator: ',', enclosure: '"', escape: "");
+    }
     foreach ($data['data'] as $row) {
       if ($haskey === FALSE) {
         array_unshift($row, $uuid_key);
@@ -1185,8 +1190,13 @@ class AmiUtilityService {
           }
         }
       }
+      if ($escape_character) {
+        $fh->fputcsv($row, separator: ',', enclosure: '"', escape: "\\");
+      }
+      else {
+        $fh->fputcsv($row, separator: ',', enclosure: '"', escape: "");
+      }
 
-      $fh->fputcsv($row);
     }
     // PHP Bug! This should happen automatically
     clearstatcache(TRUE, $url);
@@ -1213,7 +1223,6 @@ class AmiUtilityService {
     return $file->id();
   }
 
-
   /**
    * Appends CSV from array and returns file.
    *
@@ -1224,20 +1233,19 @@ class AmiUtilityService {
    *
    * @param \Drupal\file\Entity\File $file
    *
-   * @param string|null $uuid_key
+   * @param string $uuid_key
    *    IF NULL then no attempt of using UUIDS will be made.
    *    Needed for LoD Reconciling CSVs
    * @param bool $append_header
    *
-   * @param bool $escape_characters
-   *    Defaults to internal PHP mechanism for escaping characters (a "/")
-   *    Set to FALSE if you are passing JSON encoded strings into cells.
-   *    NOTE: Make sure you also disable it IF reading back from files generated through this
+   * @param bool $escape_character
+   *     If used, CSV might not end being RFC 4180 compliant.
+   * @param bool $auto_uuid
    *
    * @return int|string|null
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  public function csv_append(array $data, File $file, $uuid_key = 'node_uuid', bool $append_header = TRUE, $escape_characters = TRUE, $auto_uuid = TRUE) {
+  public function csv_append(array $data, File $file, $uuid_key = 'node_uuid', bool $append_header = TRUE, bool $escape_character = TRUE, $auto_uuid = TRUE) {
 
     $wrapper = $this->streamWrapperManager->getViaUri($file->getFileUri());
     if (!$wrapper) {
@@ -1259,7 +1267,12 @@ class AmiUtilityService {
       }
     }
     if ($append_header) {
-      $fh->fputcsv($data['headers']);
+      if ($escape_character) {
+        $fh->fputcsv($data['headers'], separator: ',', enclosure: '"', escape: "\\");
+      }
+      else {
+        $fh->fputcsv($data['headers'], separator: ',', enclosure: '"', escape: "");
+      }
     }
 
     foreach ($data['data'] as $row) {
@@ -1282,11 +1295,11 @@ class AmiUtilityService {
           }
         }
       }
-      if ($escape_characters) {
-        $fh->fputcsv($row);
+      if ($escape_character) {
+        $fh->fputcsv($row, separator: ',', enclosure: '"', escape: "\\");
       }
       else {
-        $fh->fputcsv($row, ',', '"', "");
+        $fh->fputcsv($row, separator: ',', enclosure: '"', escape: "");
       }
     }
     // PHP Bug! This should happen automatically
@@ -1310,32 +1323,32 @@ class AmiUtilityService {
    * @param bool $always_include_header
    *    Always return header even with an offset.
    *
-   * @param bool $escape_characters
-   *
+   * @param bool $escape_character
+   *     If used, CSV might not end being RFC 4180 compliant.
    * @return array|null
    *   Returning array will be in this form:
    *    'headers' => $rowHeaders_utf8 or [] if $always_include_header == FALSE
    *    'data' => $table,
    *    'totalrows' => $maxRow,
    */
-  public function csv_read(File $file, int $offset = 0, int $count = 0, bool $always_include_header = TRUE, bool $escape_characters = TRUE) {
+  public function csv_read(File $file, int $offset = 0, int $count = 0, bool $always_include_header = TRUE, bool $escape_character = FALSE) {
     // 1.6.0: wrapper around this function now that we moved it to strawberryfield so webform module does not depend on AMI for CSV reading
     // This was needed bc if not we would have an undeclared circular dependency/or would have to change all the code (many parts)
     // there this service was used to call csv_read(). Only thing new is that the logging/caller_module is used for logging now.
-    return $this->strawberryfieldUtility->csv_read($file, $offset, $count, $always_include_header, $escape_characters, 'ami');
+    return $this->strawberryfieldUtility->csv_read($file, $offset, $count, $always_include_header, $escape_character, 'ami');
   }
-
 
   /**
    *  Removes columns from an existing CSV.
    *
    * @param \Drupal\file\Entity\File $file
    * @param array $headerwithdata
-   *
+   * @param bool $escape_character
+   *     If used, CSV might not end being RFC 4180 compliant.
    * @return int|mixed|string|null
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  public function csv_clean(File $file, array $headerwithdata = []) {
+  public function csv_clean(File $file, array $headerwithdata = [], bool $escape_character = FALSE) {
     $wrapper = $this->streamWrapperManager->getViaUri($file->getFileUri());
     if (!$wrapper) {
       return NULL;
@@ -1382,7 +1395,12 @@ class AmiUtilityService {
         unset($data[$key]);
       }
       $data = array_values($data);
-      $spltmp->fputcsv($data);
+      if ($escape_character) {
+        $spltmp->fputcsv($data, separator: ',', enclosure: '"', escape: "\\");
+      }
+      else {
+        $spltmp->fputcsv($data, separator: ',', enclosure: '"', escape: "");
+      }
       $i++;
     }
     $size = $spltmp->getSize();
@@ -1399,11 +1417,11 @@ class AmiUtilityService {
   /**
    * @param \Drupal\file\Entity\File $file
    *
-   * @param bool $escape_characters
-   *
+   * @param bool $escape_character
+   *     If used, CSV might not end being RFC 4180 compliant.
    * @return int
    */
-  public function csv_count(File $file, $escape_characters = TRUE) {
+  public function csv_count(File $file, $escape_character = FALSE) {
     $wrapper = $this->streamWrapperManager->getViaUri($file->getFileUri());
     if (!$wrapper) {
       return NULL;
@@ -1419,11 +1437,11 @@ class AmiUtilityService {
       SplFileObject::DROP_NEW_LINE
     );
     while (!$spl->eof()) {
-      if (!$escape_characters) {
+      if (!$escape_character) {
         $spl->fgetcsv( ',', '"', "");
       }
       else {
-        $spl->fgetcsv();
+        $spl->fgetcsv( ',', '"', "\\");
       }
       $key = $spl->key();
     }

--- a/src/AmiUtilityService.php
+++ b/src/AmiUtilityService.php
@@ -446,6 +446,148 @@ class AmiUtilityService {
   }
 
   /**
+   * Checks if an URI exists (local/zip/remote)
+   *
+   * @param string $uri
+   *   The URL of the file to grab.
+   *
+   * @param \Drupal\file\Entity\File|NULL $zip_file
+   *
+   * @return bool
+   *    TRUE if it exists or is available to be fetched (URL)
+   *    FALSE if not.
+   */
+  public function file_check_availability($uri, File $zip_file = NULL) {
+    $uri = trim($uri);
+
+    $parsed_url = parse_url($uri);
+    $remote_schemes = ['http', 'https', 'feed'];
+    $ami_temp_folder = 'ami/setfiles/';
+    $destination = "temporary://" . $ami_temp_folder;
+    if (!isset($parsed_url['scheme'])
+      || (isset($parsed_url['scheme'])
+        && !in_array(
+          $parsed_url['scheme'],
+          $remote_schemes
+        ))
+    ) {
+      // Now that we know it's not remote, try with our registered schemas
+      // means its either private/public/s3, etc.
+      // normalize target.
+
+      $scheme = $this->streamWrapperManager->getScheme($uri);
+      if ($scheme) {
+        // Try also with our internal S3 check-if-its-there-function
+        if (!file_exists($uri) && !$this->strawberryfieldFilePersisterService->fileS3Exists($uri)) {
+          return FALSE;
+        }
+        $finaluri = $uri;
+      }
+      else {
+        // Means it may be local to the accessible file storage, eg. a path inside
+        // the server or inside a provided ZIP file
+        $localfile = $this->fileSystem->realpath($uri);
+
+        if (!$localfile && !$zip_file) {
+          return FALSE;
+        }
+        elseif ($localfile) {
+          // We can not allow DIRS. C'mon
+          if (is_dir($localfile)) {
+            return FALSE;
+          }
+          // Means the file is there already locally. Just assign.
+          $finaluri = $localfile;
+        }
+        elseif (!$localfile && $zip_file) {
+          // Means no local file but we can check inside a ZIP.
+          // Try with the ZIP file in case there is a ZIP and local failed
+          // Use the Zip file uuid to prefix the destination.
+          $localfile = $this->streamWrapperManager->normalizeUri(
+            $destination . $zip_file->uuid() . '/' . urldecode($parsed_url['path'])
+          );
+          if (!file_exists($localfile) || $force) {
+            $zip_file_exists = $this->check_fromzip_file($uri, $zip_file);
+            if ($zip_file_exists) {
+              $finaluri = $localfile;
+            }
+          }
+        }
+        $finaluri = $localfile;
+      }
+    }
+    else {
+      // This may be remote!
+      // Simulate what could be the final path of a remote download.
+      // to avoid re downloading.
+      $md5uri = md5($uri);
+      $destination = $destination . $md5uri . '/' ;
+      $path = str_replace(
+          '///',
+          '//',
+          "{$destination}"
+        ) . $this->fileSystem->basename(urldecode($parsed_url['path']));
+      $localfile = $this->streamWrapperManager->normalizeUri($path);
+      $escaped_path = str_replace(' ', '\ ', $path);
+      // This is very naive since the remote file might be different than
+      // the last part of the actual URL (header given name).
+      $isthere = glob($this->fileSystem->realpath($escaped_path) . '.*');
+      $isthere = is_array($isthere) && (count($isthere) == 1) ? $isthere : glob($this->fileSystem->realpath($escaped_path));
+
+      if (is_array($isthere) && count($isthere) == 1) {
+        // Ups its here
+        // Use path here instead of the first entry to keep the streamwrapper
+        // around for future use
+        $localfile = $path;
+      }
+      // Actual remote headers via HEAD
+      if (!file_exists($localfile) || $force) {
+        // use HEAD instead of GET
+        $stream_context = stream_context_create(
+          [
+            'http' => array(
+              'method' => 'HEAD'
+            )
+          ]
+        );
+        $remote_response_headers = @get_headers($uri,1, $stream_context);
+        if (is_array($remote_response_headers)) {
+          /* Something like this but could have redirects. So we should parse [0] as either an string or an array
+          // and find anything that is less than 400.
+           * (
+    [0] => HTTP/1.1 200 OK
+    [Date] => Sat, 29 May 2004 12:28:14 GMT
+    [Server] => Apache/1.3.27 (Unix)  (Red-Hat/Linux)
+    [Last-Modified] => Wed, 08 Jan 2003 23:11:55 GMT
+    [ETag] => "3f80f-1b6-3e1cb03b"
+    [Accept-Ranges] => bytes
+    [Content-Length] => 438
+    [Connection] => close
+    [Content-Type] => text/html
+           */
+          $remote_response_headers = $remote_response_headers[max(array_filter(array_keys($remote_response_headers), 'is_int'))] ?? '';
+          $response_code = explode(" ", $remote_response_headers ?? '')[1];
+          if (intval($response_code) >= 200 && intval($response_code) < 400) {
+            // We use the localfile/simulated one here. Does not matter if we have not yet fetched it.
+            $finaluri = $localfile;
+          }
+        }
+        else {
+          return FALSE;
+        }
+      }
+      else {
+        $finaluri = $localfile;
+      }
+    }
+    // This is the actual file creation independently of the source.
+    if ($finaluri) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
    * Attempts to get a file using drupal_http_request and to store it locally.
    *
    * @param string $url
@@ -748,6 +890,110 @@ class AmiUtilityService {
       $this->messenger()->addError(
         $this->t(
           'Unable to extract file @uri from ZIP @zip to local @path. Verify ZIP exists, its readable and destination is writable.',
+          [
+            '@uri' => $uri,
+            '@zip' => $zip_realpath,
+            '@path' => $path,
+          ]
+        )
+      );
+    }
+    return FALSE;
+  }
+
+  /**
+   * Attempts to find a file in a ZIP file without storing it.
+   *
+   * @param string $uri
+   *
+   * @param \Drupal\file\Entity\File $zip_file
+   *     A Zip file with that may contain the $uri
+   *
+   * @return false|string
+   *   One of these possibilities:
+   *   - If it succeeds a Path to a managed file object
+   *   - If it fails or NULL, FALSE.
+   */
+  public function check_fromzip_file($uri, File $zip_file = NULL) {
+    if (!$zip_file) {
+      return FALSE;
+    }
+    $zip_realpath = NULL;
+    $parsed_url = parse_url($uri);
+    if (!isset($destination)) {
+      $basename = $this->fileSystem->basename($parsed_url['path']);
+      $basename = \Drupal::config('system.file')->get('default_scheme') . '://' . $basename;
+      $path = $this->streamWrapperManager->normalizeUri($basename);
+    }
+    else {
+      if (is_dir($this->fileSystem->realpath($destination))) {
+        // Prevent URIs with triple slashes when glueing parts together.
+        $path = str_replace(
+            '///',
+            '//',
+            "{$destination}"
+          ) . $this->fileSystem->basename(
+            $parsed_url['path']
+          );
+      }
+      else {
+        $path = $destination;
+      }
+    }
+    try {
+      $zip_realpath = $this->fileSystem->realpath($zip_file->getFileUri());
+      // Means Mr. Zip is in S3 or who knows where
+      // And ZipArchive (Why!!) can not stream from remote
+      // @TODO write once for all a remote ZIP file streamer DIEGO
+      if (!$zip_realpath) {
+        // This will add a delay once...
+        $zip_realpath = $this->strawberryfieldFileMetadataService->ensureFileAvailability($zip_file, NULL);
+      }
+      $z = new \ZipArchive();
+      $contents = NULL;
+      // UTF-8 Normalization here
+      // See https://unicode.org/reports/tr15/#Introduction
+      $uri_form_c = Normalizer::normalize($uri, Normalizer::FORM_C);
+      $uri_form_d = Normalizer::normalize($uri, Normalizer::FORM_D);
+      $normalized = false;
+      if ($uri == $uri_form_c && $uri == $uri_form_d) {
+        $normalized = true;
+      }
+
+      if ($z->open($zip_realpath)) {
+        $fp = $z->getStream($uri);
+        if (!$fp && $normalized) {
+          return FALSE;
+        }
+        else {
+          if (!$fp) {
+            // try form c
+            $fp = $z->getStream($uri_form_c);
+            if (!$fp) {
+              // try form D (really edge case)
+              $fp = $z->getStream($uri_form_d);
+            }
+          }
+        }
+        if ($fp) {
+          fclose($fp);
+          return TRUE;
+        }
+        else {
+          fclose($fp);
+          return FALSE;
+        }
+      }
+      else {
+        // Opening the ZIP file failed.
+        // This might be OK if we also tried other options. Should we log it?
+        return FALSE;
+      }
+    }
+    catch (\Exception $exception) {
+      $this->messenger()->addError(
+        $this->t(
+          'Unable to find file @uri from ZIP @zip. Verify ZIP exists and its readable.',
           [
             '@uri' => $uri,
             '@zip' => $zip_realpath,
@@ -2150,6 +2396,305 @@ class AmiUtilityService {
     return $info;
   }
 
+  /**
+   * Processes a single ROW and assigns correct parents and UUIDs
+   *
+   * @param \Drupal\file\Entity\File $file
+   *   A CSV
+   * @param \stdClass $data
+   *     The AMI Set Config data
+   * @param array $invalid
+   *    Keeps track of invalid rows.
+   * @param bool $strict
+   *    TRUE means Set Config and CSV will be strictly validated,
+   *    FALSE means it will just validate for the needed elements
+   * @param int $row
+   *    The row number we actually care for.
+   *
+   * @return array
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function preprocessAmiSetSingleRow(File $file, \stdClass $data, array &$invalid = [], $strict = FALSE, int $row_id = 2): array {
+
+    // Use the AMI set user ID for checking access to entity operations.
+    $uid = $data->info['uid'] ?? \Drupal::currentUser()->id();
+    $account = $uid == \Drupal::currentUser()->id() ? \Drupal::currentUser() : $this->entityTypeManager->getStorage('user')->load($uid);
+    $file_data_all = $this->csv_read($file);
+    if (!$file_data_all) {
+      return [];
+    }
+    // We want to validate here if the found Headers match at least the
+    // Mapped ones during AMI setup. If not we will return an empty array
+    // And send a Message to the user.
+    if (!$this->validateAmiSet($file_data_all, $data, $strict)) {
+      return [];
+    }
+
+
+    $config['data']['headers'] = $file_data_all['headers'];
+    // In old times we totally depended on position, now we are going to do something different, we will combine
+    // Headers and keys.
+    $data->mapping->type_key = isset($data->mapping->type_key)
+      ? $data->mapping->type_key : 'type';
+
+    // Keeps track of all parents and child that don't have a PID assigned.
+    $parent_hash = [];
+    // Keps track of UUIDs found and their original Row Index. Adds sadly another Foreach
+    // But we need this so we can also sort CSVs where parents are all UUIDs.
+    // To do so we will count the level/deepness of a tree, and sort by shortest.
+    $uuid_to_row_index_hash = [];
+    $info = [];
+
+    // @TODO for 1.7.0/2.1.0. Optimize. bail out once a Root was found IF
+    // starting with $index == $row_id or bailout if $row_id in $failed
+
+
+    // First pass to accumulate UUIDs and their CSV order of appearance.
+    foreach ($file_data_all['data'] as $index => $keyedrow) {
+      $row = array_combine($config['data']['headers'], $keyedrow);
+      // UUIDs should be already assigned by this time
+      $possibleUUID = $row[$data->adomapping->uuid->uuid] ?? NULL;
+      $possibleUUID = $possibleUUID ? trim($possibleUUID) : $possibleUUID;
+      // Double check? User may be tricking us!
+      if ($possibleUUID && Uuid::isValid($possibleUUID)) {
+        $uuid_to_row_index_hash[$possibleUUID] = $index;
+      }
+    }
+
+    foreach ($file_data_all['data'] as $index => $keyedrow) {
+      // This makes tracking of values more consistent and easier for the actual processing via
+      // twig templates, webforms or direct
+      $row = array_combine($config['data']['headers'], $keyedrow);
+      // Each row will be an object.
+      $ado = [];
+      $ado['type'] = trim(
+        $row[$data->mapping->type_key] ?? 'Thing'
+      );
+      // Let's start by grouping by parents, namespaces and generate uuids
+      // namespaces are inherited, so we just need to find collection
+      // objects in parent uuid column.
+
+      // We may have multiple parents
+      // @dmer deal with files as parents of a node in a next iteration.
+      // So, we will here simply track also any parent
+      // Initialize in case the Mapping provides no parents
+      $ado['anyparent'] = [];
+      $ado['parent'] = [];
+      foreach (($data->adomapping->parents ?? []) as $parent_key) {
+        // Used to access parent columns using numerical indexes for when looking back inside $file_data_all
+        $parent_to_index[$parent_key] = array_search(
+          $parent_key, $config['data']['headers']
+        );
+        $parent_ados_toexpand = (array) trim(
+          $row[$parent_key]
+        );
+        $parent_ados_array = [];
+        $parent_ados_expanded = $this->expandJson($parent_ados_toexpand);
+        $parent_ados_expanded = $parent_ados_expanded[0] ?? NULL;
+        if (is_array($parent_ados_expanded)) {
+          $parent_ados_array = $parent_ados_expanded;
+        }
+        elseif (is_string($parent_ados_expanded) || is_integer($parent_ados_expanded)) {
+          // This allows single value and or ; and trims. Neat?
+          $parent_ados_array = array_map(function($value) {
+            $value = $value ?? '';
+            return trim($value);
+          }, explode(';', $parent_ados_expanded));
+        }
+
+        $ado['parent'][$parent_key] = $parent_ados_array;
+        $ado['anyparent'] = array_unique(array_merge($ado['anyparent'], $ado['parent'][$parent_key]));
+      }
+
+      $ado['data'] = $row;
+
+      // UUIDs should be already assigned by this time
+      $possibleUUID = $row[$data->adomapping->uuid->uuid] ?? NULL;
+      $possibleUUID = $possibleUUID ? trim($possibleUUID) : $possibleUUID;
+      if ($possibleUUID && isset($uuid_to_row_index_hash[$possibleUUID])) {
+        $ado['uuid'] = $possibleUUID;
+        // Now be more strict for action = update/patch or sync
+        // With the introduction of sync this gets more complex
+        if ($data->pluginconfig->op === 'sync') {
+          $sync_op = $ado['data']['ami_sync_op'] ?? 'create';
+          // only valid sync_ops are these 3
+          if ($sync_op != 'create' && in_array($sync_op, ['create','delete','update'] )) {
+            $existing_objects = $this->entityTypeManager->getStorage('node')
+              ->loadByProperties(['uuid' => $ado['uuid']]);
+            // Do access control here, will be done again during the atomic operation
+            // In case access changes later of course
+            $existing_object = $existing_objects && count($existing_objects) == 1 ? reset($existing_objects) : NULL;
+            if (!$existing_object || !$existing_object->access($sync_op, $account)) {
+              unset($ado);
+              $index = max($row_id - 2, 0 );
+              $invalid = $invalid + [$index => $index];
+            }
+          }
+          elseif (!in_array($sync_op, ['create','delete','update'])) {
+            // means invalid sync_op
+            unset($ado);
+            $invalid = $invalid + [$index => $index];
+          }
+          // Will have to read the actual OP from $ado['data']['ami_sync_op']
+          // if missing we assume ingest. Worst case it will fail bc it is already there.
+        }
+        elseif ($data->pluginconfig->op !== 'create') {
+          $existing_objects = $this->entityTypeManager->getStorage('node')
+            ->loadByProperties(['uuid' => $ado['uuid']]);
+          // Do access control here, will be done again during the atomic operation
+          // In case access changes later of course
+
+          $existing_object = $existing_objects && count($existing_objects) == 1 ? reset($existing_objects) : NULL;
+          if (!$existing_object || !$existing_object->access('update', $account)) {
+            unset($ado);
+            $invalid = $invalid + [$index => $index];
+          }
+        }
+      }
+      else {
+        unset($ado);
+        $invalid = $invalid + [$index => $index];
+      }
+
+      if (isset($ado)) {
+        //We might have multiple relationships/or none at all.
+        foreach ($ado['parent'] as $parent_key => &$parent_ados) {
+          foreach ($parent_ados as $parent_ado) {
+            $rootfound = FALSE;
+            $parent_numeric = $this->getParentRowId($parent_ado, $uuid_to_row_index_hash);
+            if ($parent_numeric === FALSE) {
+              $invalid[$parent_numeric] = $parent_numeric;
+              $invalid[$index] = $index;
+              unset($ado);
+              continue;
+            }
+            elseif ($parent_numeric === NULL) {
+              // This will also be true if there was no parent value.
+              $rootfound = TRUE;
+              continue;
+            }
+            else {
+              $parent_hash[$parent_key][$parent_numeric][$index] = $index;
+            }
+            $parentchilds = [];
+            $parent_numeric_loop = $parent_numeric;
+            while (!$rootfound) {
+              // $parentup gets the same treatment as $ado['parent']
+              $parentup_toexpand = [trim(
+                $file_data_all['data'][$parent_numeric_loop][$parent_to_index[$parent_key]]
+              )];
+              $parentup_array = [];
+              $parentup_expanded = $this->expandJson($parentup_toexpand);
+              $parentup_expanded = $parentup_expanded[0] ?? NULL;
+              if (is_array($parentup_expanded)) {
+                $parentup_array = $parent_ados_expanded;
+              }
+              elseif (is_string($parentup_expanded)
+                || is_integer(
+                  $parentup_expanded
+                )
+              ) {
+                // This allows single value and or ; and trims. Neat?
+                $parentup_array = array_map(function($value) {
+                  $value = $value ?? '';
+                  return trim($value);
+                }, explode(';', $parentup_expanded));
+              }
+
+              foreach ($parentup_array as $parentup) {
+                $parentup_numeric = $this->getParentRowId($parentup, $uuid_to_row_index_hash);
+                if ($parentup_numeric === FALSE) {
+                  $invalid[$parentup_numeric] = $parentup_numeric;
+                  $invalid[$index] = $index;
+                  unset($ado);
+                  $rootfound = TRUE;
+                  break;
+                }
+                elseif ($parentup_numeric === NULL) {
+                  $rootfound = TRUE;
+                  break;
+                }
+
+                // If $parentup
+                // The Simplest approach for breaking a knot /infinite loop,
+                // is invalidating the whole parentship chain for good.
+                $inaloop = isset($parentchilds[$parentup_numeric]);
+                // If $inaloop === true means we already traversed this branch
+                // so we are in a loop and all our original child and it's
+                // parent objects are invalid.
+                if ($inaloop) {
+                  // In a loop
+                  $invalid = $invalid + $parentchilds;
+                  unset($ado);
+                  $rootfound = TRUE;
+                  // Means this object is already doomed. We break any attempt
+                  // to get relationships for this one.
+                  break 2;
+                }
+
+                $parentchilds[$parentup_numeric] = $parentup_numeric;
+                // If this parent is either a UUID or empty means we reached the root
+                // This a simple accumulator, means all is well,
+                // parent is still an index.
+                $parent_hash[$parent_key][$parentup_numeric][$parent_numeric_loop]
+                  = $parent_numeric_loop;
+                $parent_numeric_loop = $parentup_numeric;
+              }
+            }
+          }
+        }
+      }
+      if (isset($ado) and !empty($ado)) {
+        $info[$index] = $ado;
+      }
+    }
+
+    if (isset($invalid[$row_id])) {
+      // Means our ROW is already invalid.
+      return [];
+    }
+
+    // Now the real pass, iterate over every row.
+    $parent_hash_flat = [];
+    $requested_info = [];
+    foreach ($info as $index => &$ado) {
+      foreach ($data->adomapping->parents as $parent_key) {
+        // Is this object parent of someone?
+        // at this stage $ado['parent'][$parent_key] SHOULD BE AN ARRAY IF VALID
+        if (is_array($ado['parent'][$parent_key])) {
+          foreach ($ado['parent'][$parent_key] ?? [] as $index_rel => $parentnumeric) {
+            // This will only match if the original value is a row, if not the existing UUID will be preserved?
+            if (!empty($parentnumeric) && isset($parent_hash[$parent_key][$parentnumeric])) {
+              $ado['parent'][$parent_key][$index_rel] = $info[$parentnumeric]['uuid'];
+            }
+          }
+          $ado['parent'][$parent_key] = array_filter(array_unique($ado['parent'][$parent_key]));
+        }
+        if (isset($parent_hash[$parent_key][$index])) {
+          $parent_hash_flat[$index] = array_unique(array_merge($parent_hash_flat[$index] ?? [], $parent_hash[$parent_key][$index]));
+        }
+      }
+      // Since we are reodering we may want to keep the original row_id around
+      // To help users debug which row has issues in case of ingest errors
+      $ado['row_id'] = $index;
+      if ($index == $row_id) {
+        $requested_info[] = $ado;
+      }
+    }
+
+    // But here we do not sort.
+    // We only need to return  $ado['row_id'] == $row_id
+
+    unset($parent_hash_flat);
+    unset($info);
+    unset($parent_hash);
+    unset($uuid_to_row_index_hash);
+
+    return $requested_info;
+  }
+
+
   protected function sortTreeByChildren($row_id, $tree, &$ordered, $ordered_completetree) {
     if (isset($tree[$row_id]) && !in_array($row_id, $ordered)) {
       $subtree[] = $row_id;
@@ -2348,6 +2893,34 @@ class AmiUtilityService {
    *    NULL if a UUID but not in this CSV or empty (so no parent)
    */
   protected function getParentRowId(string $parent_ado, $uuid_to_row_index_hash) {
+    $parent_numeric = FALSE;
+    if (empty($parent_ado) || strlen(trim($parent_ado)) == 0) {
+      $parent_numeric = NULL;
+    }
+    elseif (!Uuid::isValid(trim($parent_ado))
+      && is_scalar($parent_ado)
+      && (intval($parent_ado) > 1 && intval($parent_ado) <= count($uuid_to_row_index_hash)+1 )
+    ) {
+      $parent_numeric = intval(trim($parent_ado));
+    }
+    elseif (Uuid::isValid(trim($parent_ado)))  {
+      // fetch the actual ROW id using the
+      $parent_numeric = isset($uuid_to_row_index_hash[trim($parent_ado)]) ? $uuid_to_row_index_hash[trim($parent_ado)] : NULL;
+    }
+    return  $parent_numeric;
+  }
+
+  /**
+   * Callback to get the Index number in the CSV File of a parent numeric id
+   * or uuid. This literally searches the CSV File itself.
+   *
+   * @param string $parent
+   *
+   * @return int|null|bool
+   *    FALSE if not present at all
+   *    NULL if a UUID but not in this CSV or empty (so no parent)
+   */
+  protected function getParentRowIdFromCSV(File $file, string $parent_ado, $uuid_to_row_index_hash) {
     $parent_numeric = FALSE;
     if (empty($parent_ado) || strlen(trim($parent_ado)) == 0) {
       $parent_numeric = NULL;

--- a/src/Controller/AmiQueueWorkerPreviewHandler.php
+++ b/src/Controller/AmiQueueWorkerPreviewHandler.php
@@ -398,7 +398,6 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
                 // the actual behavior will be determined by a column named "ami_sync_op"
               }
               if ($data_ado->pluginconfig->op !== 'action' && !$skip) {
-                
                 $ado_entity = $this->simulateQueueItem($data_ado, $parsed_json);
                 $build = [];
                 $content_selector = 'ami-preview-container';
@@ -418,8 +417,22 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
                     '#attributes' => ['id' => $content_selector],
                     'preview_wrapper' => $render_array
                   ];
+                  if (!empty($parsed_json)) {
+                    $dialog_content['body']['json'] = [
+                      '#type' => 'fieldset',
+                      '#collapsible' => TRUE,
+                      '#collapsed' => TRUE,
+                      '#title' => $this->t('Raw JSON produced by row @row', ['@row' => $row_id]),
+                      '#attributes' => ['id' => $content_selector . '-json'],
+                      'json_raw' =>  [
+                        '#type' => 'markup',
+                        '#prefix' => '<pre>',
+                        '#suffix' => '</pre>',
+                        '#markup' => json_encode($parsed_json, JSON_PRETTY_PRINT) ?? '{}'
+                        ]
+                    ];
+                  }
                 }
-
 
                 // 3. Open the modal dialog overlay
                 $title = $this->t('AMI ADO Preview for "@label" with UUID @uuid', [
@@ -427,8 +440,8 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
                   '@uuid' => $ado_entity->uuid(),
                 ]);
                 $options =  [
-                  'height' => '75%',
-                  'width' => '75%',
+                  'height' => '85%',
+                  'width' => '85%',
                 ];
                 $response->addCommand(new OpenModalDialogCommand($title, $dialog_content, $options));
                 $response->addAttachments([
@@ -437,7 +450,6 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
                     'ami/ami_preview_helper'
                   ],
                 ]);
-
               }
             }
           }
@@ -1699,7 +1711,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
             // extra CSS classes added to the diff container <div> in HTML renderers
             wrapperClasses: ['diff-wrapper'],
           );
-          $jsonResult = DiffHelper::calculate($build_existing, $build, 'Json'); // may store the JSON result in your database
+          $jsonResult = DiffHelper::calculate($build_existing, $build, 'Json', $differOptions); // may store the JSON result in your database
           $htmlRenderer = RendererFactory::make($rendererName, $rendererOptions);
           $result = $htmlRenderer->renderArray(json_decode($jsonResult, true));
           $render_array['preview']['#attributes']['id'] = 'ami-preview-container-ado';

--- a/src/Controller/AmiQueueWorkerPreviewHandler.php
+++ b/src/Controller/AmiQueueWorkerPreviewHandler.php
@@ -20,12 +20,10 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\strawberryfield\Event\StrawberryfieldFileEvent;
 use Drupal\strawberryfield\StrawberryfieldEventType;
 use Drupal\strawberryfield\StrawberryfieldFilePersisterService;
 use Drupal\strawberryfield\StrawberryfieldUtilityService;
-use Drupal\views\Entity\View;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Swaggest\JsonDiff\JsonDiff;
 use Jfcherng\Diff\DiffHelper;
@@ -38,8 +36,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Drupal\views_bulk_operations\Service\ViewsBulkOperationsActionManager;
 use Drupal\views_bulk_operations\Service\ViewsBulkOperationsActionProcessorInterface;
 use Drupal\Core\Session\AccountSwitcherInterface;
-use Drupal\Core\Access\AccessResultReasonInterface;
-use Drupal\Core\Action\ActionInterface;
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Ajax\MessageCommand;
 use Drupal\Core\Ajax\OpenModalDialogCommand;
@@ -157,13 +153,14 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
   protected $renderer;
 
   /**
+   * Helper property to keep the patched JSON around.
+   */
+   protected ?string $json_patch = NULL;
+
+  /**
    * Constructor.
    *
-   * @param array $configuration
-   * @param string $plugin_id
-   * @param mixed $plugin_definition
    * @param EntityTypeManagerInterface $entity_type_manager
-   * @param LoggerChannelFactoryInterface $logger_factory
    * @param StrawberryfieldUtilityService $strawberryfield_utility_service
    * @param AmiUtilityService $ami_utility
    * @param AmiLoDService $ami_lod
@@ -171,9 +168,8 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
    * @param StrawberryfieldFilePersisterService $strawberry_filepersister
    * @param PrivateTempStoreFactory $temp_store_factory
    * @param EventDispatcherInterface $event_dispatcher
-   * @param ViewsBulkOperationsActionManager $actionManager
-   * @param ViewsBulkOperationsActionProcessorInterface $actionProcessor
    * @param AccountSwitcherInterface $accountSwitcher
+   * @param \Drupal\Core\Render\RendererInterface $renderer
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
@@ -230,10 +226,10 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
     /** @var \Drupal\format_strawberryfield\MetadataDisplayInterface $entity */
     $ami_set_entity = $form_state->getFormObject()->getEntity();
     // We have two choices here.
-    // A) Keep the code as similar as \Drupal\ami\Plugin\QueueWorker\IngestADOQueueWorker
+    // A, Keep the code as similar as \Drupal\ami\Plugin\QueueWorker\IngestADOQueueWorker
     // which implies generating a $data structure as it was meant for the CSV expander
     // then let the Same Code Generate a $data structure for the Ingest ADO queue woker
-    // or B) skip steps/go for the final $data structure. Which requires on any future updates on processing code
+    // or B. skip steps/go for the final $data structure. Which requires on any future updates on processing code
     // to also mimic it here.
     // It is a bummer i can not just re-use logic, but this is a form driven process v/s a queue one and
     // there is no persistence so i need the ADO state in a single method as return.
@@ -244,11 +240,23 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
     $row_id = $form_state->getValue('ado_amiset_preview_row', 2);
     if ($row_id < 2) { $row_id = 2; }
     $render_diff = (bool) $form_state->getValue('ado_amiset_preview_diff_rendered', FALSE);
+    $render_json_diff = (bool) $form_state->getValue('ado_amiset_preview_diff_json', FALSE);
+    $content_selector = 'ami-preview-container';
+    $message_selector = 'ami-preview-messages-container';
+    $dialog_content = [
+      '#type' => 'container',
+      '#attributes' => ['id' => $message_selector], // Wrapper used for message placement
+      'body' => [
+        '#markup' => '<p></p>',
+      ],
+    ];
+    // 3. Open the modal dialog overlay
+    $dialog_title = $this->t('AMI Preview');
     $ops_skip_onmissing_file = (bool) $form_state->getValue('skip_onmissing_file', TRUE);
     $ops_forcemanaged_destination_file = (bool) $form_state->getValue('take_control_file', TRUE);
 
     // Normalize Un Moderadet Statuses if 0 and 1
-    foreach ($statuses as $bundle => &$value) {
+    foreach ($statuses as &$value) {
       if ($value == "1") {
         $value = 1;
       }
@@ -258,6 +266,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
     }
 
     $csv_file_reference = $ami_set_entity->get('source_data')->getValue();
+    $file = NULL;
     if (isset($csv_file_reference[0]['target_id'])) {
       /** @var \Drupal\file\Entity\File $file */
       $file = $this->entityTypeManager->getStorage('file')->load(
@@ -280,19 +289,14 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
       $data = $item->provideDecoded(FALSE);
     }
     if ($file && $data !== new \stdClass()) {
-      $invalid = [];
       $SetURL = $ami_set_entity->toUrl('canonical', ['absolute' => TRUE])
         ->toString();
 
       $run_timestamp = \Drupal::time()->getCurrentTime();
-
-      $notprocessnow = $form_state->getValue('not_process_now', NULL);
-      $added = [];
       $op_secondary = NULL;
       // Only applies to Update/Patch operations but for contract reasons
       // we generate all $data->info the same.
       $ops_safefiles = TRUE;
-      $last_processed_config = [];
 
       if (isset($data->pluginconfig->op) && $data->pluginconfig->op != 'create') {
         $op_secondary = $form_state->getValue(['ops_secondary','ops_secondary_update'], 'update');
@@ -321,13 +325,10 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
         'time_submitted' => $run_timestamp
       ];
 
-
-
       try {
         $data_ado = clone $data_csv;
         $data_ado->info = NULL;
         $added = [];
-        $ado = NULL;
         $csv_file = $data_csv->info['csv_file'] ?? NULL;
         if ($csv_file instanceof FileInterface) {
           $invalid = [];
@@ -337,123 +338,119 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
             if (!count($info)) {
               //@TODO tell the user which CSV failed please?
               $message = $this->t('So sorry. CSV @csv for @setid produced no ADOs. Please correct your source CSV data', [
-                '@setid' => $data_ado->info['set_id'],
-                '@csv' => $csv_file->getFilename(),
+                '@setid' => $data_ado->info['set_id'] ?? 'Undefined AMI set',
+                '@csv' => $csv_file->getFilename() ?? 'Unknown CSV File',
               ]);
-               $this->messenger->addError($message);
-              return $response;
+              $this->messenger->addError($message);
             }
-
-            foreach ($info as $item) {
-              // We set current User here since we want to be sure the final owner of
-              // the object is this and not the user that runs the queue
-              $data_ado->info = [
-                'zip_file' => $data_csv->info['zip_file'] ?? NULL,
-                'row' => $item,
-                'set_id' => $data_csv->info['set_id'],
-                'uid' => $data_csv->info['uid'],
-                'status_keep' => $data_csv->info['status_keep'] ?? FALSE,
-                'status' => $data_csv->info['status'],
-                'op_secondary' => $data_csv->info['op_secondary'] ?? NULL,
-                'ops_safefiles' => $data_csv->info['ops_safefiles'] ? TRUE : FALSE,
-                'log_jsonpatch' => FALSE,
-                'set_url' => $data_csv->info['set_url'],
-                'attempt' => 1,
-                'queue_name' => $data_csv->info['queue_name'],
-                'force_file_queue' => $data_csv->info['force_file_queue'],
-                'force_file_process' => $data_csv->info['force_file_process'],
-                'manyfiles' => $data_csv->info['manyfiles'],
-                'ops_skip_onmissing_file' => $data_csv->info['ops_skip_onmissing_file'],
-                'ops_forcemanaged_destination_file' => $data_csv->info['ops_forcemanaged_destination_file'],
-                'time_submitted' => $data_csv->info['time_submitted'],
-              ];
-              // Overrides in case we are in a sync operation.
-              $valid_op = TRUE;
-              $skip = FALSE;
-              if ($data_ado->pluginconfig->op == 'sync') {
-                // Important we will move the data driven (ami_sync_op) info the que info
-                // structure secondary.
-                // Fixed key:
-                $sync_op = $item['data']['ami_sync_op'] ?? 'create';
-                if ($sync_op === 'create') {
-                  $data_ado->info['op_secondary'] = 'create';
-                }
-                elseif ($sync_op === 'update') {
-                  $data_ado->info['op_secondary'] = 'update';
-                }
-                elseif ($sync_op === 'delete') {
-                  // This needs to go a different queue.
-                  $skip = TRUE;
-                  // We only need the UUIDs to delete.
-                  // Will we allow a Sync operation to delete a TOP and automatically delete all the children?
-                  // If so we need to pass the CSV data also to this array.
-                  // $uuids_sync_action should be formed the way $this->AmiUtilityService->getProcessedAmiSetNodeUUids($csv_file, $data, NULL); would.
-                  // For now safer to not. We are deleting direct references of deletion of a ROW.
-                  $uuids_sync_action[$item['uuid'] ?? ''] = [];
-                }
-                else {
-                  $skip = TRUE;
-                  // Flag as false?
-                }
-                // the actual behavior will be determined by a column named "ami_sync_op"
-              }
-              if ($data_ado->pluginconfig->op !== 'action' && !$skip) {
-                $ado_entity = $this->simulateQueueItem($data_ado, $parsed_json);
-                $build = [];
-                $content_selector = 'ami-preview-container';
-                $message_selector = 'ami-preview-messages-container';
-                $dialog_content = [
-                  '#type' => 'container',
-                  '#attributes' => ['id' => $message_selector], // Wrapper used for message placement
-                  'body' => [
-                    '#markup' => '<p></p>',
-                  ],
+            else {
+              foreach ($info as $item) {
+                // We set current User here since we want to be sure the final owner of
+                // the object is this and not the user that runs the queue
+                $data_ado->info = [
+                  'zip_file' => $data_csv->info['zip_file'] ?? NULL,
+                  'row' => $item,
+                  'set_id' => $data_csv->info['set_id'],
+                  'uid' => $data_csv->info['uid'],
+                  'status_keep' => $data_csv->info['status_keep'] ?? FALSE,
+                  'status' => $data_csv->info['status'],
+                  'op_secondary' => $data_csv->info['op_secondary'] ?? NULL,
+                  'ops_safefiles' => $data_csv->info['ops_safefiles'] ? TRUE : FALSE,
+                  'log_jsonpatch' => FALSE,
+                  'set_url' => $data_csv->info['set_url'],
+                  'attempt' => 1,
+                  'queue_name' => $data_csv->info['queue_name'],
+                  'force_file_queue' => $data_csv->info['force_file_queue'],
+                  'force_file_process' => $data_csv->info['force_file_process'],
+                  'manyfiles' => $data_csv->info['manyfiles'],
+                  'ops_skip_onmissing_file' => $data_csv->info['ops_skip_onmissing_file'],
+                  'ops_forcemanaged_destination_file' => $data_csv->info['ops_forcemanaged_destination_file'],
+                  'time_submitted' => $data_csv->info['time_submitted'],
                 ];
-                if ($ado_entity) {
-                  $added[] = $ado_entity->uuid();
-                  $render_array = $this->processAdoDiff($ado_entity, $render_diff);
-                  $dialog_content['body'] = [
-                    '#type' => 'container',
-                    '#attributes' => ['id' => $content_selector],
-                    'preview_wrapper' => $render_array
-                  ];
-                  if (!empty($parsed_json)) {
-                    $dialog_content['body']['json'] = [
-                      '#type' => 'fieldset',
-                      '#collapsible' => TRUE,
-                      '#collapsed' => TRUE,
-                      '#title' => $this->t('Raw JSON produced by row @row', ['@row' => $row_id]),
-                      '#attributes' => ['id' => $content_selector . '-json'],
-                      'json_raw' =>  [
-                        '#type' => 'markup',
-                        '#prefix' => '<pre>',
-                        '#suffix' => '</pre>',
-                        '#markup' => json_encode($parsed_json, JSON_PRETTY_PRINT) ?? '{}'
-                        ]
-                    ];
+                // Overrides in case we are in a sync operation.
+                $skip = FALSE;
+                if ($data_ado->pluginconfig->op == 'sync') {
+                  // Important we will move the data driven (ami_sync_op) info the que info
+                  // structure secondary.
+                  // Fixed key:
+                  $sync_op = $item['data']['ami_sync_op'] ?? 'create';
+                  if ($sync_op === 'create') {
+                    $data_ado->info['op_secondary'] = 'create';
                   }
+                  elseif ($sync_op === 'update') {
+                    $data_ado->info['op_secondary'] = 'update';
+                  }
+                  elseif ($sync_op === 'delete') {
+                    // This needs to go a different queue.
+                    $skip = TRUE;
+                    // We only need the UUIDs to delete.
+                    // Will we allow a Sync operation to delete a TOP and automatically delete all the children?
+                    // If so we need to pass the CSV data also to this array.
+                    // $uuids_sync_action should be formed the way $this->AmiUtilityService->getProcessedAmiSetNodeUUids($csv_file, $data, NULL); would.
+                    // For now safer to not. We are deleting direct references of deletion of a ROW.
+                    $uuids_sync_action[$item['uuid'] ?? ''] = [];
+                  }
+                  else {
+                    $skip = TRUE;
+                    // Flag as false?
+                  }
+                  // the actual behavior will be determined by a column named "ami_sync_op"
                 }
+                if ($data_ado->pluginconfig->op !== 'action' && !$skip) {
+                  $ado_entity = $this->simulateQueueItem($data_ado, $parsed_json);
+                  $build = [];
 
-                // 3. Open the modal dialog overlay
-                $title = $this->t('AMI ADO Preview for "@label" with UUID @uuid', [
-                  '@label' => $ado_entity->label(),
-                  '@uuid' => $ado_entity->uuid(),
-                ]);
-                $options =  [
-                  'height' => '85%',
-                  'width' => '85%',
-                ];
-                $response->addCommand(new OpenModalDialogCommand($title, $dialog_content, $options));
-                $response->addAttachments([
-                  'library' => [
-                    'core/drupal.dialog.ajax',
-                    'ami/ami_preview_helper'
-                  ],
-                ]);
+                  if ($ado_entity) {
+                    $added[] = $ado_entity->uuid();
+                    $render_array = $this->processAdoDiff($ado_entity, $render_diff);
+                    $dialog_content['body'] = [
+                      '#type' => 'container',
+                      '#attributes' => ['id' => $content_selector],
+                      'preview_wrapper' => $render_array
+                    ];
+                    if (!empty($parsed_json)) {
+                      $dialog_content['body']['json'] = [
+                        '#type' => 'fieldset',
+                        '#collapsible' => TRUE,
+                        '#collapsed' => TRUE,
+                        '#title' => $this->t('Raw JSON produced by row @row', ['@row' => $row_id]),
+                        '#attributes' => ['id' => $content_selector . '-json'],
+                        'json_raw' => [
+                          '#type' => 'markup',
+                          '#prefix' => '<pre>',
+                          '#suffix' => '</pre>',
+                          '#markup' => json_encode($parsed_json, JSON_PRETTY_PRINT) ?? '{}'
+                        ]
+                      ];
+                    }
+                    if ($render_json_diff) {
+                      if ($patched_json = $this->getJsonPatch()) {
+                        $dialog_content['body']['json_diff'] = [
+                          '#type' => 'fieldset',
+                          '#collapsible' => TRUE,
+                          '#collapsed' => TRUE,
+                          '#title' => $this->t('JSON Diff as JSON Patch'),
+                          '#attributes' => ['id' => $content_selector . '-json-diff'],
+                          'json_raw' => [
+                            '#type' => 'markup',
+                            '#prefix' => '<pre>',
+                            '#suffix' => '</pre>',
+                            '#markup' => $patched_json
+                          ]
+                        ];
+                      }
+                    }
+                  }
+
+                  // 3. Open the modal dialog overlay
+                  $dialog_title = $this->t('AMI ADO Preview for "@label" with UUID @uuid', [
+                    '@label' => $ado_entity->label(),
+                    '@uuid' => $ado_entity->uuid(),
+                  ]);
+                }
               }
             }
           }
-         
 
           if (!in_array($data_ado->pluginconfig->op ?? 'missing op', [
             'action',
@@ -463,10 +460,10 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
             'patch'
           ])) {
             $message = $this->t('Set @setid has a non valid Operation @op. We can not expand the CSV', [
-              '@setid' => $data_ado->info['set_id'],
-              '@op' => $data_ado->pluginconfig->op,
+              '@setid' => $data_ado->info['set_id'] ?? 'Undefined AMI set',
+              '@op' => $data_ado->pluginconfig->op ?? 'Undefined Operation',
             ]);
-             $this->messenger->addError($message);
+            $this->messenger->addError($message);
           }
           if (count($invalid)) {
             $invalid_message = $this->formatPlural(count($invalid),
@@ -481,7 +478,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
           if (!count($added)) {
             $message = $this->t('CSV @csv for Set @setid generated no ADOs. Check your CSV for missing UUIDs and other required elements', [
               '@setid' => $data_ado->info['set_id'] ?? 'Undefined AMI set ID',
-              '@csv' => $csv_file->getFilename(),
+              '@csv' => $csv_file->getFilename() ?? 'Unknown CSV File',
             ]);
             $this->messenger->addError($message);
           }
@@ -490,19 +487,31 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
           $message = $this->t('The referenced CSV @filename from Set @setid, enqueued to be expanded, could not be found. Skipping',
             [
               '@setid' => $data_ado->info['set_id'] ?? 'Undefined AMI set ID',
-              '@filename' => $data_ado->info['csv_filename'] ?? 'Undefined CSV Filename',
+              '@filename' => $csv_file->getFilename() ?? 'Unknown CSV File',
             ]);
-           $this->messenger->addError($message);
+          $this->messenger->addError($message);
         }
       }
       catch (\Throwable $exception) {
+        // Here $data_ado won't be available
         $message = $this->t('Sorry, something failed badly while we attempted to Expand an AMI set CSV into multiple ADO Ingest and Action Queue Items on Set @setid with error @error. This is quite strange. Please check your Drupal Logs and notify your admin.', [
-          '@setid' => $data_ado->info['set_id'] ?? 'Undefined AMI set ID',
+          '@setid' => $data_csv->info['set_id'] ?? 'Undefined AMI set ID',
           '@error' => $exception->getMessage(),
         ]);
-         $this->messenger->addError($message);
+        $this->messenger->addError($message);
       }
     }
+    $options =  [
+      'height' => '85%',
+      'width' => '85%',
+    ];
+    $response->addCommand(new OpenModalDialogCommand($dialog_title, $dialog_content, $options));
+    $response->addAttachments([
+      'library' => [
+        'core/drupal.dialog.ajax',
+        'ami/ami_preview_helper'
+      ],
+    ]);
     $messages = $this->messenger->deleteAll();
     foreach ($messages as $type => $type_messages) {
       foreach ($type_messages as $message) {
@@ -527,8 +536,6 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
         $file_csv_columns = array_values(get_object_vars($csv_file_object));
       }
 
-      $persisted = FALSE;
-      $should_process = TRUE;
       $should_process_simulated = $this->canProcess($data);
       // On the actual queue worker we would bail out ::canProcess returning false. But here we want to accumulate the messages
       // and give the user feedback while stile trying to at least render a representation even if
@@ -553,17 +560,11 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
               '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
               '@parent_uuids' => implode(',', $parent_uuids)
             ]);
-             $this->messenger->addError($message);
+            $this->messenger->addError($message);
             $parent_nodes[$parent_property] = [];
-            foreach ($existing as $node) {
-              $parent_nodes[$parent_property][] = (int) $node->id();
-            }
           }
-          else {
-            // Get the IDs!
-            foreach ($existing as $node) {
-              $parent_nodes[$parent_property][] = (int) $node->id();
-            }
+          foreach ($existing as $node) {
+            $parent_nodes[$parent_property][] = (int) $node->id();
           }
         }
       }
@@ -581,7 +582,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
             '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
             '@setid' => $data->info['set_id']
           ]);
-           $this->messenger->addError($message);
+          $this->messenger->addError($message);
           // Here we actuall return FALSE BC there is no possible rendering situation.
           return FALSE;
         }
@@ -592,7 +593,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
             '@uuid' => $data->info['row']['uuid'] ?? "MISSING UUID",
             '@setid' => $data->info['set_id']
           ]);
-           $this->messenger->addError($message);
+          $this->messenger->addError($message);
           return FALSE;
         }
         elseif (!isset($data->info['row']['data'])) {
@@ -600,7 +601,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
             [
               '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
             ]);
-           $this->messenger->addError($message);
+          $this->messenger->addError($message);
           return FALSE;
         }
 
@@ -612,7 +613,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
             '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
             '@setid' => $data->info['set_id']
           ]);
-           $this->messenger->addError($message);
+          $this->messenger->addError($message);
           return FALSE;
         }
       }
@@ -628,7 +629,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
           '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
           '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
         ]);
-         $this->messenger->addError($message);
+        $this->messenger->addError($message);
         return FALSE;
       }
 
@@ -709,7 +710,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
               '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
               '@count' => $number_of_files
             ]);
-             $this->messenger->addStatus($message);
+            $this->messenger->addStatus($message);
           }
           foreach ($filenames as $filename) {
             $filename = trim($filename);
@@ -748,7 +749,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
                     '@filename' => $filename ?? 'Undefined Filename',
                     '@filecolumn' => $file_column ?? 'Undefined File CSV Column',
                   ]);
-                 $this->messenger->addError($message);
+                $this->messenger->addError($message);
               }
             }
           }
@@ -762,7 +763,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
             '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
             '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
           ]);
-         $this->messenger->addError($message);
+        $this->messenger->addError($message);
       }
       // Only persist if we passed this.
       // True if all ok, to the best of our knowledge of course
@@ -806,29 +807,17 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
           '@error' => $exception->getMessage(),
           '@uuid' => $data->info['uuids'] ?? 'Unknown UUID',
         ]);
-       $this->messenger->addError($message);
+      $this->messenger->addError($message);
       return FALSE;
     }
   }
 
+  public function getJsonPatch(): ?string {
+    return $this->json_patch;
+  }
 
-  /**
-   * Quick helper is Remote or local helper
-   *
-   * @param $uri
-   *
-   * @return bool
-   */
-  private function isRemote($uri) {
-    // WE do have a similar code in \Drupal\ami\AmiUtilityService::file_get
-    // @TODO refactor to a single method.
-    $parsed_url = parse_url($uri);
-    $remote_schemes = ['http', 'https', 'feed'];
-    $remote = FALSE;
-    if (isset($parsed_url['scheme']) && in_array($parsed_url['scheme'], $remote_schemes)) {
-      $remote = TRUE;
-    }
-    return $remote;
+  public function setJsonPatch(?string $json_patch): void {
+    $this->json_patch = $json_patch;
   }
 
   /**
@@ -865,10 +854,10 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
     try {
       // @TODO: $property_path, if null should return with failure. Also on the Queue worker
       if ($data->mapping->globalmapping == "custom") {
-        $property_path = $data->mapping->custommapping_settings->{$data->info['row']['type']}->bundle ?? NULL;
+        $property_path = $data->mapping->custommapping_settings->{$data->info['row']['type']}->bundle ?? '';
       }
       else {
-        $property_path = $data->mapping->globalmapping_settings->bundle ?? NULL;
+        $property_path = $data->mapping->globalmapping_settings->bundle ?? '';
       }
 
       $label_column = $data->adomapping->base->label ?? 'label';
@@ -891,12 +880,13 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
           '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
           '@setid' => $data->info['set_id']
         ]);
-       $this->messenger->addError($message);
-       return FALSE;
+        $this->messenger->addError($message);
+        return FALSE;
       }
 
       $bundle = $property_path_split[0];
       $field_name = $property_path_split[1];
+
       // @TODO make this configurable.
       // This would allows us to pass an offset if the SBF is multivalued.
       // WE do not do this, Why would you want that? Who knows but possible.
@@ -1040,10 +1030,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
                     }
                     $processed_metadata = $original_value;
                   }
-                  //@TODO. Since we are previewing, maybe on Updates we SHOULD always show to the end user this patch?
-                  if (isset($data->info['log_jsonpatch']) && $data->info['log_jsonpatch']) {
-                    $this->patchJson($original_value ?? [], $processed_metadata ?? [], TRUE);
-                  }
+
 
                   if ($op_secondary == 'append') {
                     $processed_metadata_keys = array_keys($processed_metadata);
@@ -1149,6 +1136,8 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
                   }
 
                   $itemfield->setMainValueFromArray($processed_metadata);
+
+                  $this->setJsonPatch($this->patchJson($original_value ?? [], $processed_metadata ?? [], TRUE));
                   break;
                 }
               }
@@ -1187,7 +1176,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
             '%title' => $label ?? 'Unnamed ADO',
             '@ophuman' => $op == $op_original ? static::OP_HUMAN[$op] : static::OP_HUMAN[$op] . ' and ' . static::OP_HUMAN[$op_original]
           ]);
-           $this->messenger->addStatus($message);
+          $this->messenger->addStatus($message);
           return $node ?? FALSE;
         }
         catch (\Throwable $exception) {
@@ -1197,7 +1186,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
             '@ophuman' => $op == $op_original ? static::OP_HUMAN[$op] : static::OP_HUMAN[$op] . ' and ' . static::OP_HUMAN[$op_original],
             '@e' => $exception->getMessage()
           ]);
-           $this->messenger->addError($message);
+          $this->messenger->addError($message);
           return FALSE;
         }
       }
@@ -1207,7 +1196,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
           '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
           '@ophuman' => $op == $op_original ? static::OP_HUMAN[$op] : static::OP_HUMAN[$op] . ' and ' . static::OP_HUMAN[$op_original]
         ]);
-         $this->messenger->addError($message);
+        $this->messenger->addError($message);
         return FALSE;
       }
     }
@@ -1218,13 +1207,13 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
         '@ophuman' => $op == $op_original ? (static::OP_HUMAN[$op] ?? "Undefined operation") : (static::OP_HUMAN[$op] ?? "Undefined operation"). ' and ' . (static::OP_HUMAN[$op_original] ?? "Undefined operation"),
         '@error' => $exception->getMessage(),
       ]);
-       $this->messenger->addError($message);
+      $this->messenger->addError($message);
       return FALSE;
     }
   }
 
   /**
-   * Will return a Patched array using on original/new arrays.
+   * Will return a Patched array as string using on original/new arrays.
    *
    * @param array $original
    * @param array $new
@@ -1232,7 +1221,8 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
    * @param bool $reverse
    *     If true we will generate an UNDO patch
    *
-   * @return false|string
+   * @return string
+   *    On failure, it will return an empty JSON encoded object.
    */
   protected function patchJson(array $original, array $new, $reverse = FALSE) {
     // IMPORTANT:
@@ -1262,10 +1252,10 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
       $patch = $r->getPatch()->jsonSerialize();
     }
     catch (\Swaggest\JsonDiff\Exception $exception) {
-      // We do not want to make ingesting slower. Just return [];
+      // We do not want to make processing slower. Just return '{}';
       return '{}';
     }
-    return json_encode($patch ?? []);
+    return json_encode($patch ?? []) ?? '{}';
   }
 
   /**
@@ -1294,7 +1284,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
             '@setid' => $data->info['set_id'] ?? 'Unknown Set',
             '@filename' => $data->info['filename']
           ]);
-         $this->messenger->addError($message);
+        $this->messenger->addError($message);
         return FALSE;
       }
     }
@@ -1305,7 +1295,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
           '@filename' => $data->info['filename'],
           '@error' => $e->getMessage(),
         ]);
-       $this->messenger->addError($message);
+      $this->messenger->addError($message);
       return FALSE;
     }
   }
@@ -1387,7 +1377,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
           '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
           '@setid' => $data->info['set_id']
         ]);
-         $this->messenger->addWarning($message);
+        $this->messenger->addWarning($message);
 
         return NULL;
       }
@@ -1397,8 +1387,8 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
           '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
           '@ophuman' => static::OP_HUMAN[$op],
         ]);
-        
-         $this->messenger->addWarning($message);
+
+        $this->messenger->addWarning($message);
         return FALSE;
       }
       $account = $data->info['uid'] == \Drupal::currentUser()
@@ -1413,7 +1403,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
             '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
             '@ophuman' => static::OP_HUMAN[$op],
           ]);
-           $this->messenger->addWarning($message);
+          $this->messenger->addWarning($message);
           return FALSE;
         }
       }
@@ -1426,7 +1416,7 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
         '@ophuman' => static::OP_HUMAN[$op],
         '@error' => $e->getMessage()
       ]);
-       $this->messenger->addError($message);
+      $this->messenger->addError($message);
 
       return FALSE;
     }
@@ -1535,7 +1525,10 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
     $render_array = [];
 
 
-
+    // We could instead of loading the ADO from storage, check if during this process
+    // we generated a new revision on $ado. BUT. We can't assume EVERY strawberryfield
+    // will have revisions. The user could create a new Field/New Bundle and set no revisions
+    // SO re-loading is safer.
     $uuid = $ado->uuid();
     $viewBuilder = \Drupal::entityTypeManager()->getViewBuilder('node');
     $view_mode = \Drupal::service('format_strawberryfield.view_mode_resolver')->get($ado);
@@ -1552,8 +1545,6 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
           'rel' => 'noopener noreferrer',
         ]
       ]);
-
-
 
     $ado->preview_view_mode = $view_mode;
     $ado->in_preview = TRUE;
@@ -1721,7 +1712,6 @@ class AmiQueueWorkerPreviewHandler extends ControllerBase {
     }
     return $render_array;
   }
-
 }
 
 

--- a/src/Controller/AmiQueueWorkerPreviewHandler.php
+++ b/src/Controller/AmiQueueWorkerPreviewHandler.php
@@ -1,0 +1,1715 @@
+<?php
+
+namespace Drupal\ami\Controller;
+
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\file\Entity\File;
+use Drupal\ami\AmiLoDService;
+use Drupal\ami\AmiUtilityService;
+use Drupal\ami\Entity\amiSetEntity;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\file\FileInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\strawberryfield\Event\StrawberryfieldFileEvent;
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Drupal\strawberryfield\StrawberryfieldFilePersisterService;
+use Drupal\strawberryfield\StrawberryfieldUtilityService;
+use Drupal\views\Entity\View;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Swaggest\JsonDiff\JsonDiff;
+use Jfcherng\Diff\DiffHelper;
+use Jfcherng\Diff\Factory\RendererFactory;
+use Jfcherng\Diff\Options\DifferOptions;
+use Jfcherng\Diff\Options\RendererOptions;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Drupal\views_bulk_operations\Service\ViewsBulkOperationsActionManager;
+use Drupal\views_bulk_operations\Service\ViewsBulkOperationsActionProcessorInterface;
+use Drupal\Core\Session\AccountSwitcherInterface;
+use Drupal\Core\Access\AccessResultReasonInterface;
+use Drupal\Core\Action\ActionInterface;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Ajax\MessageCommand;
+use Drupal\Core\Ajax\OpenModalDialogCommand;
+use Drupal\Core\Render\RenderContext;
+
+/**
+ * Simulates AMI Queue Worker Ingest/Update/Sync without persisting an ADO.
+ *
+ */
+class AmiQueueWorkerPreviewHandler extends ControllerBase {
+
+  use StringTranslationTrait;
+  use DependencySerializationTrait;
+  /**
+   * Drupal\Core\Entity\EntityTypeManager definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The Strawberry Field Utility Service.
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldUtilityService
+   */
+  protected $strawberryfieldUtility;
+
+
+  /**
+   * @var \Drupal\ami\AmiUtilityService
+   */
+  protected $AmiUtilityService;
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * @var \Drupal\ami\AmiLoDService
+   */
+  protected $AmiLoDService;
+
+  /**
+   * The Strawberryfield File Persister Service
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldFilePersisterService
+   */
+  protected $strawberryfilepersister;
+
+  /**
+   * @var \Drupal\Core\TempStore\PrivateTempStore
+   */
+  protected $store;
+
+  /**
+   * Private Store used to keep the Set Processing Status/count
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStore
+   */
+  protected $statusStore;
+
+  /**
+   * Private Store used to keep the Set Processing Status/count
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStore
+   */
+  protected $contextStore;
+
+  /**
+   * The AMI specific logger
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Human language past tense for operations.
+   *
+   * @var array
+   */
+  protected CONST OP_HUMAN = [
+    'create' => 'created',
+    'update' => 'updated',
+    'patch' => 'patched',
+    'sync' => 'synced',
+  ];
+
+  /**
+   * The event dispatcher.
+   *
+   * @var EventDispatcherInterface
+   */
+  protected EventDispatcherInterface $eventDispatcher;
+
+  /**
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   */
+  protected PrivateTempStoreFactory $privateStoreFactory;
+
+  /**
+   * The current_user service used by this plugin.
+   *
+   * @var \Drupal\Core\Session\AccountSwitcherInterface|null
+   */
+  protected $accountSwitcher;
+
+  /**
+   * The Drupal Renderer.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * Constructor.
+   *
+   * @param array $configuration
+   * @param string $plugin_id
+   * @param mixed $plugin_definition
+   * @param EntityTypeManagerInterface $entity_type_manager
+   * @param LoggerChannelFactoryInterface $logger_factory
+   * @param StrawberryfieldUtilityService $strawberryfield_utility_service
+   * @param AmiUtilityService $ami_utility
+   * @param AmiLoDService $ami_lod
+   * @param MessengerInterface $messenger
+   * @param StrawberryfieldFilePersisterService $strawberry_filepersister
+   * @param PrivateTempStoreFactory $temp_store_factory
+   * @param EventDispatcherInterface $event_dispatcher
+   * @param ViewsBulkOperationsActionManager $actionManager
+   * @param ViewsBulkOperationsActionProcessorInterface $actionProcessor
+   * @param AccountSwitcherInterface $accountSwitcher
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    StrawberryfieldUtilityService $strawberryfield_utility_service,
+    AmiUtilityService $ami_utility,
+    AmiLoDService $ami_lod,
+    MessengerInterface $messenger,
+    StrawberryfieldFilePersisterService $strawberry_filepersister,
+    PrivateTempStoreFactory $temp_store_factory,
+    EventDispatcherInterface $event_dispatcher,
+    AccountSwitcherInterface $accountSwitcher,
+    RendererInterface $renderer,
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->strawberryfieldUtility = $strawberryfield_utility_service;
+    $this->AmiUtilityService = $ami_utility;
+    $this->messenger = $messenger;
+    $this->AmiLoDService = $ami_lod;
+    $this->strawberryfilepersister = $strawberry_filepersister;
+    $this->store = $temp_store_factory->get('ami_queue_worker_file');
+    $this->statusStore = $temp_store_factory->get('ami_queue_status');
+    $this->contextStore = $temp_store_factory->get('ami_action_context');
+    $this->eventDispatcher = $event_dispatcher;
+    $this->accountSwitcher = $accountSwitcher;
+    $this->renderer = $renderer;
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('strawberryfield.utility'),
+      $container->get('ami.utility'),
+      $container->get('ami.lod'),
+      $container->get('messenger'),
+      $container->get('strawberryfield.file_persister'),
+      $container->get('tempstore.private'),
+      $container->get('event_dispatcher'),
+      $container->get('account_switcher'),
+      $container->get('renderer'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function simulateItemAjax(array $form, FormStateInterface $form_state) {
+    $response = new AjaxResponse();
+    $parsed_json = [];
+
+    /** @var \Drupal\format_strawberryfield\MetadataDisplayInterface $entity */
+    $ami_set_entity = $form_state->getFormObject()->getEntity();
+    // We have two choices here.
+    // A) Keep the code as similar as \Drupal\ami\Plugin\QueueWorker\IngestADOQueueWorker
+    // which implies generating a $data structure as it was meant for the CSV expander
+    // then let the Same Code Generate a $data structure for the Ingest ADO queue woker
+    // or B) skip steps/go for the final $data structure. Which requires on any future updates on processing code
+    // to also mimic it here.
+    // It is a bummer i can not just re-use logic, but this is a form driven process v/s a queue one and
+    // there is no persistence so i need the ADO state in a single method as return.
+
+    $manyfiles = $this->config('strawberryfield.filepersister_service_settings')->get('manyfiles') ?? 0;
+    $statuses = $form_state->getValue('status', []);
+    $status_keep = $form_state->getValue('status_keep', FALSE) ? TRUE : FALSE;
+    $row_id = $form_state->getValue('ado_amiset_preview_row', 2);
+    if ($row_id < 2) { $row_id = 2; }
+    $render_diff = (bool) $form_state->getValue('ado_amiset_preview_diff_rendered', FALSE);
+    $ops_skip_onmissing_file = (bool) $form_state->getValue('skip_onmissing_file', TRUE);
+    $ops_forcemanaged_destination_file = (bool) $form_state->getValue('take_control_file', TRUE);
+
+    // Normalize Un Moderadet Statuses if 0 and 1
+    foreach ($statuses as $bundle => &$value) {
+      if ($value == "1") {
+        $value = 1;
+      }
+      elseif ($value == "0") {
+        $value = 0;
+      }
+    }
+
+    $csv_file_reference = $ami_set_entity->get('source_data')->getValue();
+    if (isset($csv_file_reference[0]['target_id'])) {
+      /** @var \Drupal\file\Entity\File $file */
+      $file = $this->entityTypeManager->getStorage('file')->load(
+        $csv_file_reference[0]['target_id']
+      );
+    }
+
+    // Fetch Zip file if any
+    $zip_file = NULL;
+    $zip_file_reference = $ami_set_entity->get('zip_file')->getValue();
+    if (isset($zip_file_reference[0]['target_id'])) {
+      /** @var \Drupal\file\Entity\File $zip_file */
+      $zip_file = $this->entityTypeManager->getStorage('file')->load(
+        $zip_file_reference[0]['target_id']
+      );
+    }
+    $data = new \stdClass();
+    foreach ($ami_set_entity->get('set') as $item) {
+      /** @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $item */
+      $data = $item->provideDecoded(FALSE);
+    }
+    if ($file && $data !== new \stdClass()) {
+      $invalid = [];
+      $SetURL = $ami_set_entity->toUrl('canonical', ['absolute' => TRUE])
+        ->toString();
+
+      $run_timestamp = \Drupal::time()->getCurrentTime();
+
+      $notprocessnow = $form_state->getValue('not_process_now', NULL);
+      $added = [];
+      $op_secondary = NULL;
+      // Only applies to Update/Patch operations but for contract reasons
+      // we generate all $data->info the same.
+      $ops_safefiles = TRUE;
+      $last_processed_config = [];
+
+      if (isset($data->pluginconfig->op) && $data->pluginconfig->op != 'create') {
+        $op_secondary = $form_state->getValue(['ops_secondary','ops_secondary_update'], 'update');
+        $ops_safefiles = $form_state->getValue(['ops_secondary','ops_safefiles'], TRUE);
+      }
+      $data_csv = clone $data;
+      // Testing the CSV processor
+      $data_csv->info = [
+        'zip_file' => $zip_file,
+        'csv_file' => $file,
+        'set_id' => $ami_set_entity->id(),
+        'uid' => $this->currentUser()->id(),
+        'status' => $statuses,
+        'status_keep' => $status_keep ? TRUE: FALSE,
+        'op_secondary' => $op_secondary,
+        'ops_safefiles' => $ops_safefiles ? TRUE : FALSE,
+        'log_jsonpatch' => FALSE,
+        'set_url' => $SetURL,
+        'attempt' => 1,
+        'queue_name' => NULL,
+        'force_file_queue' => (bool)$form_state->getValue('force_file_queue', FALSE),
+        'force_file_process' => (bool)$form_state->getValue('force_file_process', FALSE),
+        'manyfiles' => $manyfiles,
+        'ops_skip_onmissing_file' => $ops_skip_onmissing_file,
+        'ops_forcemanaged_destination_file' => $ops_forcemanaged_destination_file,
+        'time_submitted' => $run_timestamp
+      ];
+
+
+
+      try {
+        $data_ado = clone $data_csv;
+        $data_ado->info = NULL;
+        $added = [];
+        $ado = NULL;
+        $csv_file = $data_csv->info['csv_file'] ?? NULL;
+        if ($csv_file instanceof FileInterface) {
+          $invalid = [];
+          $uuids_sync_action = [];
+          if ($data_ado->pluginconfig->op !== 'action') {
+            $info = $this->AmiUtilityService->preprocessAmiSetSingleRow($csv_file, $data_ado, $invalid, FALSE, $row_id);
+            if (!count($info)) {
+              //@TODO tell the user which CSV failed please?
+              $message = $this->t('So sorry. CSV @csv for @setid produced no ADOs. Please correct your source CSV data', [
+                '@setid' => $data_ado->info['set_id'],
+                '@csv' => $csv_file->getFilename(),
+              ]);
+               $this->messenger->addError($message);
+              return $response;
+            }
+
+            foreach ($info as $item) {
+              // We set current User here since we want to be sure the final owner of
+              // the object is this and not the user that runs the queue
+              $data_ado->info = [
+                'zip_file' => $data_csv->info['zip_file'] ?? NULL,
+                'row' => $item,
+                'set_id' => $data_csv->info['set_id'],
+                'uid' => $data_csv->info['uid'],
+                'status_keep' => $data_csv->info['status_keep'] ?? FALSE,
+                'status' => $data_csv->info['status'],
+                'op_secondary' => $data_csv->info['op_secondary'] ?? NULL,
+                'ops_safefiles' => $data_csv->info['ops_safefiles'] ? TRUE : FALSE,
+                'log_jsonpatch' => FALSE,
+                'set_url' => $data_csv->info['set_url'],
+                'attempt' => 1,
+                'queue_name' => $data_csv->info['queue_name'],
+                'force_file_queue' => $data_csv->info['force_file_queue'],
+                'force_file_process' => $data_csv->info['force_file_process'],
+                'manyfiles' => $data_csv->info['manyfiles'],
+                'ops_skip_onmissing_file' => $data_csv->info['ops_skip_onmissing_file'],
+                'ops_forcemanaged_destination_file' => $data_csv->info['ops_forcemanaged_destination_file'],
+                'time_submitted' => $data_csv->info['time_submitted'],
+              ];
+              // Overrides in case we are in a sync operation.
+              $valid_op = TRUE;
+              $skip = FALSE;
+              if ($data_ado->pluginconfig->op == 'sync') {
+                // Important we will move the data driven (ami_sync_op) info the que info
+                // structure secondary.
+                // Fixed key:
+                $sync_op = $item['data']['ami_sync_op'] ?? 'create';
+                if ($sync_op === 'create') {
+                  $data_ado->info['op_secondary'] = 'create';
+                }
+                elseif ($sync_op === 'update') {
+                  $data_ado->info['op_secondary'] = 'update';
+                }
+                elseif ($sync_op === 'delete') {
+                  // This needs to go a different queue.
+                  $skip = TRUE;
+                  // We only need the UUIDs to delete.
+                  // Will we allow a Sync operation to delete a TOP and automatically delete all the children?
+                  // If so we need to pass the CSV data also to this array.
+                  // $uuids_sync_action should be formed the way $this->AmiUtilityService->getProcessedAmiSetNodeUUids($csv_file, $data, NULL); would.
+                  // For now safer to not. We are deleting direct references of deletion of a ROW.
+                  $uuids_sync_action[$item['uuid'] ?? ''] = [];
+                }
+                else {
+                  $skip = TRUE;
+                  // Flag as false?
+                }
+                // the actual behavior will be determined by a column named "ami_sync_op"
+              }
+              if ($data_ado->pluginconfig->op !== 'action' && !$skip) {
+                
+                $ado_entity = $this->simulateQueueItem($data_ado, $parsed_json);
+                $build = [];
+                $content_selector = 'ami-preview-container';
+                $message_selector = 'ami-preview-messages-container';
+                $dialog_content = [
+                  '#type' => 'container',
+                  '#attributes' => ['id' => $message_selector], // Wrapper used for message placement
+                  'body' => [
+                    '#markup' => '<p></p>',
+                  ],
+                ];
+                if ($ado_entity) {
+                  $added[] = $ado_entity->uuid();
+                  $render_array = $this->processAdoDiff($ado_entity, $render_diff);
+                  $dialog_content['body'] = [
+                    '#type' => 'container',
+                    '#attributes' => ['id' => $content_selector],
+                    'preview_wrapper' => $render_array
+                  ];
+                }
+
+
+                // 3. Open the modal dialog overlay
+                $title = $this->t('AMI ADO Preview for "@label" with UUID @uuid', [
+                  '@label' => $ado_entity->label(),
+                  '@uuid' => $ado_entity->uuid(),
+                ]);
+                $options =  [
+                  'height' => '75%',
+                  'width' => '75%',
+                ];
+                $response->addCommand(new OpenModalDialogCommand($title, $dialog_content, $options));
+                $response->addAttachments([
+                  'library' => [
+                    'core/drupal.dialog.ajax',
+                    'ami/ami_preview_helper'
+                  ],
+                ]);
+
+              }
+            }
+          }
+         
+
+          if (!in_array($data_ado->pluginconfig->op ?? 'missing op', [
+            'action',
+            'sync',
+            'create',
+            'update',
+            'patch'
+          ])) {
+            $message = $this->t('Set @setid has a non valid Operation @op. We can not expand the CSV', [
+              '@setid' => $data_ado->info['set_id'],
+              '@op' => $data_ado->pluginconfig->op,
+            ]);
+             $this->messenger->addError($message);
+          }
+          if (count($invalid)) {
+            $invalid_message = $this->formatPlural(count($invalid),
+              'Source data Row @row had an issue, common cause is an invalid parent.',
+              '@count rows, @row, had issues, common causes are invalid parents and/or non existing referenced rows.',
+              [
+                '@row' => implode(', ', array_keys($invalid)),
+              ]
+            );
+            $this->messenger->addError($invalid_message);
+          }
+          if (!count($added)) {
+            $message = $this->t('CSV @csv for Set @setid generated no ADOs. Check your CSV for missing UUIDs and other required elements', [
+              '@setid' => $data_ado->info['set_id'] ?? 'Undefined AMI set ID',
+              '@csv' => $csv_file->getFilename(),
+            ]);
+            $this->messenger->addError($message);
+          }
+        }
+        else {
+          $message = $this->t('The referenced CSV @filename from Set @setid, enqueued to be expanded, could not be found. Skipping',
+            [
+              '@setid' => $data_ado->info['set_id'] ?? 'Undefined AMI set ID',
+              '@filename' => $data_ado->info['csv_filename'] ?? 'Undefined CSV Filename',
+            ]);
+           $this->messenger->addError($message);
+        }
+      }
+      catch (\Throwable $exception) {
+        $message = $this->t('Sorry, something failed badly while we attempted to Expand an AMI set CSV into multiple ADO Ingest and Action Queue Items on Set @setid with error @error. This is quite strange. Please check your Drupal Logs and notify your admin.', [
+          '@setid' => $data_ado->info['set_id'] ?? 'Undefined AMI set ID',
+          '@error' => $exception->getMessage(),
+        ]);
+         $this->messenger->addError($message);
+      }
+    }
+    $messages = $this->messenger->deleteAll();
+    foreach ($messages as $type => $type_messages) {
+      foreach ($type_messages as $message) {
+        $response->addCommand(new MessageCommand($message, '#'.$message_selector, ['type' => $type], FALSE));
+      }
+    }
+    return $response;
+  }
+
+
+  private function simulateQueueItem($data, &$parsed_json) {
+    try {
+      $file_csv_columns = [];
+      if ($data->mapping->globalmapping == "custom") {
+        $csv_file_object = $data->mapping->custommapping_settings->{$data->info['row']['type']}->files_csv ?? NULL;
+      }
+      else {
+        $csv_file_object = $data->mapping->globalmapping_settings->files_csv ?? NULL;
+      }
+
+      if ($csv_file_object && is_object($csv_file_object)) {
+        $file_csv_columns = array_values(get_object_vars($csv_file_object));
+      }
+
+      $persisted = FALSE;
+      $should_process = TRUE;
+      $should_process_simulated = $this->canProcess($data);
+      // On the actual queue worker we would bail out ::canProcess returning false. But here we want to accumulate the messages
+      // and give the user feedback while stile trying to at least render a representation even if
+      // actual processing would fail when done for real.
+      $parent_nodes = [];
+      if (isset($data->info['row']['parent']) && is_array($data->info['row']['parent'])) {
+        $parents = $data->info['row']['parent'];
+        $parents = array_filter($parents);
+        foreach ($parents as $parent_property => $parent_uuid) {
+          $parent_uuids = (array) $parent_uuid;
+          // We should validate each member to be an UUID here (again). Just in case?
+          $existing = $this->entityTypeManager->getStorage('node')
+            ->loadByProperties(['uuid' => $parent_uuids]);
+
+          // For preview. The parent could be literally another row to be ingested by the same AMI
+          // set. So instead of bailing out in case the parent has not been ingested
+          // we should just report as "make sure the parent ADO is ingested too"
+
+          if (count($existing) != count($parent_uuids)) {
+            $message = $this->t('Sorry, we can not process ADO with @uuid from Set @setid yet, there are missing parents with UUID(s) @parent_uuids.', [
+              '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+              '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+              '@parent_uuids' => implode(',', $parent_uuids)
+            ]);
+             $this->messenger->addError($message);
+            $parent_nodes[$parent_property] = [];
+            foreach ($existing as $node) {
+              $parent_nodes[$parent_property][] = (int) $node->id();
+            }
+          }
+          else {
+            // Get the IDs!
+            foreach ($existing as $node) {
+              $parent_nodes[$parent_property][] = (int) $node->id();
+            }
+          }
+        }
+      }
+
+      $processed_metadata = NULL;
+
+      $method = $data->mapping->globalmapping ?? "direct";
+      if ($method == 'custom') {
+        $method = $data->mapping->custommapping_settings->{$data->info['row']['type']}->metadata ?? "direct";
+      }
+      if ($method == 'template') {
+        $processed_metadata = $this->AmiUtilityService->processMetadataDisplay($data);
+        if (!$processed_metadata) {
+          $message = $this->t('Sorry, we can not cast ADO with @uuid into proper Metadata. Check the Metadata Display Template used, your permissions and/or your data ROW in your CSV for set @setid.', [
+            '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+            '@setid' => $data->info['set_id']
+          ]);
+           $this->messenger->addError($message);
+          // Here we actuall return FALSE BC there is no possible rendering situation.
+          return FALSE;
+        }
+      }
+      if ($method == "direct") {
+        if (isset($data->info['row']['data']) && !is_array($data->info['row']['data'])) {
+          $message = $this->t('Sorry, we can not cast ADO with @uuid directly into proper Metadata. Check your data ROW in your CSV for set @setid for invalid data.', [
+            '@uuid' => $data->info['row']['uuid'] ?? "MISSING UUID",
+            '@setid' => $data->info['set_id']
+          ]);
+           $this->messenger->addError($message);
+          return FALSE;
+        }
+        elseif (!isset($data->info['row']['data'])) {
+          $message = $this->t('Sorry, we can not cast an ADO directly into proper Metadata. Check your data ROW in your CSV for set @setid for invalid data.',
+            [
+              '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+            ]);
+           $this->messenger->addError($message);
+          return FALSE;
+        }
+
+        $processed_metadata = $this->AmiUtilityService->expandJson($data->info['row']['data']);
+        $processed_metadata = !empty($processed_metadata) ? json_encode($processed_metadata) : NULL;
+        $json_error = json_last_error();
+        if ($json_error !== JSON_ERROR_NONE || !$processed_metadata) {
+          $message = $this->t('Sorry, we can not cast ADO with @uuid directly into proper Metadata. Check your data ROW in your CSV for set @setid for invalid JSON data.', [
+            '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+            '@setid' => $data->info['set_id']
+          ]);
+           $this->messenger->addError($message);
+          return FALSE;
+        }
+      }
+
+      // If at this stage $processed_metadata is empty or Null there was a wrong
+      // Manual added wrong mapping or any other User input induced error
+      // We do not process further
+      // Maybe someone wants to ingest FILES only without any Metadata?
+      // Not a good use case so let's stop that nonsense here.
+
+      if (empty($processed_metadata)) {
+        $message = $this->t('Sorry, ADO with @uuid is empty or has wrong data/metadata. Check your data ROW in your CSV for set @setid or your Set Configuration for manually entered JSON that may break your setup.', [
+          '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+          '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+        ]);
+         $this->messenger->addError($message);
+        return FALSE;
+      }
+
+      $cleanvalues = [];
+      // Now process Files and Nodes
+      $ado_object = $data->adomapping->parents ?? NULL;
+
+      if (($data->mapping->globalmapping ?? FALSE) == "custom") {
+        $file_object = $data->mapping->custommapping_settings->{$data->info['row']['type']}->files ?? NULL;
+      }
+      else {
+        $file_object = $data->mapping->globalmapping_settings->files ?? NULL;
+      }
+
+      $file_columns = [];
+
+      $ado_columns = [];
+      if ($file_object && is_object($file_object)) {
+        $file_columns = array_values(get_object_vars($file_object));
+      }
+
+      if ($ado_object && is_object($ado_object)) {
+        $ado_columns = array_values(get_object_vars($ado_object));
+      }
+
+      // deal with possible overrides from either Direct ingest of
+      // A Smart twig template that adds extra mappings
+      // This decode will always work because we already decoded and encoded again.
+      $processed_metadata = json_decode($processed_metadata, TRUE);
+      $processed_metadata['ap:entitymapping'] = isset($processed_metadata['ap:entitymapping']) && is_array($processed_metadata['ap:entitymapping']) ? $processed_metadata['ap:entitymapping'] : [];
+      $custom_file_mapping = isset($processed_metadata['ap:entitymapping']['entity:file']) && is_array($processed_metadata['ap:entitymapping']['entity:file']) ? $processed_metadata['ap:entitymapping']['entity:file'] : [];
+      $custom_node_mapping = isset($processed_metadata['ap:entitymapping']['entity:node']) && is_array($processed_metadata['ap:entitymapping']['entity:node']) ? $processed_metadata['ap:entitymapping']['entity:node'] : [];
+
+      $entity_mapping_structure['entity:file'] = array_unique(array_merge($custom_file_mapping, $file_columns));
+      $entity_mapping_structure['entity:node'] = array_unique(array_merge($custom_node_mapping, $ado_columns));
+      // Unset so we do not lose our merge after '+' both arrays
+      unset($processed_metadata['ap:entitymapping']);
+
+      $cleanvalues['ap:entitymapping'] = $entity_mapping_structure;
+      $processed_metadata = $processed_metadata + $cleanvalues;
+      // Assign parents as NODE Ids.
+      foreach ($parent_nodes as $parent_property => $node_ids) {
+        $processed_metadata[$parent_property] = $node_ids;
+      }
+      $processed_files = 0;
+      $process_files_via_queue = FALSE;
+
+      // Now do heavy file lifting
+      $allfiles = TRUE;
+      foreach ($file_columns as $file_column) {
+        // Why 5? one character + one dot + 3 for the extension
+        if (isset($data->info['row']['data'][$file_column]) && is_string($data->info['row']['data'][$file_column]) && strlen(trim($data->info['row']['data'][$file_column])) >= 5) {
+          $filenames = trim($data->info['row']['data'][$file_column]);
+          $filenames = array_map(function($value) {
+            $value = $value ?? '';
+            $value = is_string($value) ? $value : '';
+            return trim($value);
+          }, explode(';', $filenames));
+
+          // Someone can just pass a ";" and we end with an empty which means a while folder, remove the thing!
+          $filenames = array_filter($filenames);
+          // Clear first. Who knows whats in there. May be a file string that will eventually fail. We should not allow anything coming
+          // From the template neither.
+          // @TODO ask users. But this also means Templates can not PROVIDE FIXTURES/PREEXISTING FILES
+          $processed_metadata[$file_column] = [];
+
+          // Now the hard part. Do we have too many files?
+          $file_limit = $data->info['manyfiles'] ?? 0;
+          if (($data->info['force_file_queue'] ?? FALSE) || (($file_limit != 0) && (count($filenames) + $processed_files > $file_limit) && empty($data->info['waiting_for_files']))) {
+            // We will add future files to the queue...
+            // accumulating all the ones we need
+            // and at the end
+            // re-enqueue this little one
+            $process_files_via_queue = TRUE;
+            $number_of_files = count($filenames ?? []) + $processed_files ?? 0;
+            $message = $this->t('Associated Files for ADO with @uuid would be automatically processed as individual Queue items bc of their count: @count', [
+              '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+              '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+              '@count' => $number_of_files
+            ]);
+             $this->messenger->addStatus($message);
+          }
+          foreach ($filenames as $filename) {
+            $filename = trim($filename);
+            if (empty($data->info['waiting_for_files'])) {
+              // Always produce now the data structure so we can call processFile either via a queue or
+              // via process file.
+              $reduced = (count($filenames) + $processed_files >= $file_limit) && ($file_limit != 0);
+              $data_file = new \stdClass();
+              // Any changed data from a previous run, like SET ID, ZIP FILE, processed ROW
+              // Should force us to regenerate the private storage. That is key here.
+              // Why? We could have changed our processing strategy, the file column, etc!
+              $data_file->info = [
+                'zip_file' => $data->info['zip_file'],
+                'set_id' => $data->info['set_id'],
+                'uid' => $data->info['uid'],
+                'processed_row' => $processed_metadata,
+                'file_column' => $file_column,
+                'filename' => $filename,
+                'attempt' => 1,
+                'queue_name' => $data->info['queue_name'],
+                'uuid' => $data->info['row']['uuid'],
+                'force_file_process' => $data->info['force_file_process'],
+                'reduced' => $reduced,
+                'ops_forcemanaged_destination_file' => $data->info['ops_forcemanaged_destination_file'] ?? TRUE,
+                'time_submitted' => $data->info['time_submitted'],
+              ];
+
+              // Do the file processing synchronously bc we are simulating
+              $file_exists = $this->checkFileAvailability($data_file);
+              if (!$file_exists) {
+                $allfiles = FALSE;
+                $message = $this->t('Sorry, for ADO with UUID:@uuid, File @filename at column @filecolumn would not be processed. We would Skip. Please check your CSV for set @setid.',
+                  [
+                    '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+                    '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+                    '@filename' => $filename ?? 'Undefined Filename',
+                    '@filecolumn' => $file_column ?? 'Undefined File CSV Column',
+                  ]);
+                 $this->messenger->addError($message);
+              }
+            }
+          }
+        }
+      }
+
+
+      if (!empty($data->info['ops_skip_onmissing_file'] && $data->info['ops_skip_onmissing_file'] == TRUE && !$allfiles)) {
+        $message = $this->t('We would skip ADO with UUID:@uuid because one or more files could not be processed and <em>Skip ADO processing on missing File</em> is enabled',
+          [
+            '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+            '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+          ]);
+         $this->messenger->addError($message);
+      }
+      // Only persist if we passed this.
+      // True if all ok, to the best of our knowledge of course
+      $ado = $this->processEntity($data, $processed_metadata);
+      $parsed_json = $processed_metadata;
+      return $ado;
+
+      // We only process a CSV column IF and only if the row that contains it generated an ADO
+      // or the ADO was already there.
+      if (($ado || !$should_process) && !empty($file_csv_columns)) {
+        $current_row_id = $data->info['row']['row_id'] ?? NULL;
+        $data_csv = clone $data;
+        unset($data_csv->info['row']);
+        foreach ($file_csv_columns as $file_csv_column) {
+          if (isset($data->info['row']['data'][$file_csv_column]) && strlen(trim($data->info['row']['data'][$file_csv_column])) >= 5) {
+            $filenames = trim($data->info['row']['data'][$file_csv_column]);
+            $filenames = array_map(function($value) {
+              $value = $value ?? '';
+              return trim($value);
+            }, explode(';', $filenames));
+            $filenames = array_filter($filenames);
+            // We will keep the original row ID, so we can log it.
+            $data_csv->info['row']['row_id'] = $current_row_id;
+            foreach ($filenames as $filename) {
+              $data_csv->info['csv_filename'] = $filename;
+              // $csv_file = $this->processCSvFile($data_csv);
+              //if ($csv_file) {
+              //$data_csv->info['csv_file'] = $csv_file;
+              // Push to the CSV  queue
+              // }
+            }
+          }
+        }
+      }
+    }
+    catch (\Throwable $exception) {
+      // Catch for not handled File processing errors.
+      $message = $this->t('Error Processing ADOs with UUID @uuid for set @setid with unexpected error @error. This queue item will be skipped and will not be re-queued.',
+        [
+          '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+          '@error' => $exception->getMessage(),
+          '@uuid' => $data->info['uuids'] ?? 'Unknown UUID',
+        ]);
+       $this->messenger->addError($message);
+      return FALSE;
+    }
+  }
+
+
+  /**
+   * Quick helper is Remote or local helper
+   *
+   * @param $uri
+   *
+   * @return bool
+   */
+  private function isRemote($uri) {
+    // WE do have a similar code in \Drupal\ami\AmiUtilityService::file_get
+    // @TODO refactor to a single method.
+    $parsed_url = parse_url($uri);
+    $remote_schemes = ['http', 'https', 'feed'];
+    $remote = FALSE;
+    if (isset($parsed_url['scheme']) && in_array($parsed_url['scheme'], $remote_schemes)) {
+      $remote = TRUE;
+    }
+    return $remote;
+  }
+
+  /**
+   * Processes an ADO (NODE Entity) without saving
+   *
+   * @param \stdClass $data
+   * @param array $processed_metadata
+   *
+   * @return \Drupal\Core\Entity\ContentEntityInterface|\Drupal\Core\Entity\EntityInterface|\Drupal\Core\Entity\EntityPublishedInterface|false
+   *   Returns ADO or FALSE if it could not be processed.
+   */
+  private function processEntity(\stdClass $data, array $processed_metadata) {
+    //OP can be one of:
+    /*
+    'create' => 'Create New ADOs',
+    'update' => 'Update existing ADOs',
+    'patch' => 'Patch existing ADOs',
+    'delete' => 'Delete existing ADOs',
+    'sync' => 'Sync' -> which will have op_secondary as the actual OP.
+    */
+    $op = $op_original = $data->pluginconfig->op;
+    $op_secondary =  $data->info['op_secondary'] ?? NULL;
+    if ($op === 'sync') {
+      if ($op_secondary == "create") {
+        $op = "create";
+        $op_secondary = NULL;
+      }
+      if ($op_secondary == "update") {
+        $op = "update";
+        // $op_secondary stays untouched.
+      }
+    }
+
+    try {
+      // @TODO: $property_path, if null should return with failure. Also on the Queue worker
+      if ($data->mapping->globalmapping == "custom") {
+        $property_path = $data->mapping->custommapping_settings->{$data->info['row']['type']}->bundle ?? NULL;
+      }
+      else {
+        $property_path = $data->mapping->globalmapping_settings->bundle ?? NULL;
+      }
+
+      $label_column = $data->adomapping->base->label ?? 'label';
+      // Always (because of processed metadata via template) try to fetch again the mapped version
+      $label = $processed_metadata[$label_column] ?? ($processed_metadata['label'] ?? NULL);
+      // SOME PEOPLE USING LABEL AS AN ARRAY? GOSH.
+      if (is_array($label)) {
+        $label = reset($label);
+        $label = is_string($label) ? $label : NULL;
+      }
+      elseif (is_object($label)) {
+        // No guessing. People get your data right. We NULL-i-fy
+        $label = NULL;
+      }
+
+      $property_path_split = explode(':', $property_path ?? '');
+
+      if (!$property_path_split || count($property_path_split) < 2) {
+        $message = $this->t('Sorry, your Bundle/Fields to Type mapping for the requested an ADO with @uuid on Set @setid are wrong. You might have an unmapped type, or might have made a larger change in your repo and deleted a Content Type. Aborting.', [
+          '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+          '@setid' => $data->info['set_id']
+        ]);
+       $this->messenger->addError($message);
+       return FALSE;
+      }
+
+      $bundle = $property_path_split[0];
+      $field_name = $property_path_split[1];
+      // @TODO make this configurable.
+      // This would allows us to pass an offset if the SBF is multivalued.
+      // WE do not do this, Why would you want that? Who knows but possible.
+      // @see also \Drupal\ami\AmiUtilityService::processMetadataDisplay
+      $field_name_offset = $property_path_split[2] ?? 0;
+      // Fall back to not published in case no status was passed.
+      $status = $data->info['status'][$bundle] ?? 0;
+      // This is tricky. String 1 v/s integer one
+      if ($status == "1") {
+        $status = 1;
+      }
+      if ($status == "0") {
+        $status = 0;
+      }
+      $status_keep = $data->info['status_keep'] ?? FALSE;
+      // default Sortfile which will respect the ingest order. If there was already one set, preserve.
+      $sort_files = isset($processed_metadata['ap:tasks']) && isset($processed_metadata['ap:tasks']['ap:sortfiles']) ? $processed_metadata['ap:tasks']['ap:sortfiles'] : 'index';
+      // We can't blindly override ap:tasks if we are dealing with an update operation. So make an exception here for only create
+      // And deal with the same for update but later
+      if ($op === 'create') {
+        if (isset($processed_metadata['ap:tasks']) && is_array($processed_metadata['ap:tasks'])) {
+          $processed_metadata['ap:tasks']['ap:sortfiles'] = $sort_files;
+        }
+        else {
+          $processed_metadata['ap:tasks'] = [];
+          $processed_metadata['ap:tasks']['ap:sortfiles'] = $sort_files;
+        }
+      }
+
+      // JSON_ENCODE AGAIN!
+      $jsonstring = json_encode($processed_metadata, JSON_PRETTY_PRINT, 50);
+
+      if ($jsonstring) {
+        // Correct to send Label as NULL here if the user messed up..
+        $nodeValues = [
+          'uuid' => $data->info['row']['uuid'],
+          'type' => $bundle,
+          'title' => $label,
+          'uid' => $data->info['uid'],
+          $field_name => $jsonstring
+        ];
+
+        /** @var \Drupal\Core\Entity\EntityPublishedInterface $node */
+        try {
+          if ($op === 'create') {
+            if ($status && is_string($status)) {
+              // String here means we got moderation_status;
+              $nodeValues['moderation_state'] = $status;
+              $status = 0; // Let the Moderation Module set the right value
+            }
+            $node = $this->entityTypeManager->getStorage('node')
+              ->create($nodeValues);
+          }
+          else {
+            // This is duplication. We already load existing to check
+            // If we can proceed in \Drupal\ami\Plugin\QueueWorker\IngestADOQueueWorker::canProcess
+            // But it is cleaner to make that function boolean
+            // And re useable than return existing from there.
+            /** @var \Drupal\Core\Entity\ContentEntityInterface[] $existing */
+            $existing = $this->entityTypeManager->getStorage('node')
+              ->loadByProperties(
+                ['uuid' => $data->info['row']['uuid']]
+              );
+            // Ups ... should never happen but what if just after checking race/condition it is gone?
+            $existing_object = reset($existing);
+
+            $vid = $this->entityTypeManager
+              ->getStorage('node')
+              ->getLatestRevisionId($existing_object->id());
+
+            $node = $vid ? $this->entityTypeManager->getStorage('node')
+              ->loadRevision($vid) : $existing_object;
+
+            /** @var \Drupal\Core\Field\FieldItemInterface $field */
+            $field = $node->get($field_name);
+            // Ignore status for updates if status_keep == TRUE.
+            if ($status && is_string($status) && $status_keep == FALSE) {
+              $node->set('moderation_state', $status);
+              $nodeValues['moderation_state'] = $status;
+              $status = 0;
+            }
+            /** @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
+            if (!$field->isEmpty()) {
+              /** @var $field \Drupal\Core\Field\FieldItemList */
+              foreach ($field->getIterator() as $delta => $itemfield) {
+                /** @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $itemfield */
+                if ($field_name_offset == $delta) {
+                  $original_value = $itemfield->provideDecoded(TRUE);
+                  // Now calculate what we need to do here regarding files/node mappings
+                  $original_file_mappings = $original_value['ap:entitymapping']['entity:file'] ?? [];
+                  $original_node_mappings = $original_value['ap:entitymapping']['entity:node'] ?? [];
+
+                  // This will preserve existing File Keys/values/mappings
+                  foreach ($original_file_mappings as $filekey) {
+                    if (!in_array($filekey, $processed_metadata['ap:entitymapping']['entity:file'])) {
+                      $processed_metadata[$filekey] = $original_value[$filekey] ?? [];
+                      $processed_metadata['ap:entitymapping']['entity:file'][] = $filekey;
+                    }
+                    else {
+                      // Means new processing is adding these, and they are already in the mapping. Is safe Files enabled?
+                      if ($data->info['ops_safefiles']) {
+                        // We take the old file ids and merge the new ones. Nothing gets lost ever.
+                        // If there were no new ones, or new ones were URLs and failed processing
+                        // The $processed_metadata[$filekey] might be a string or empty!
+                        $processed_metadata[$filekey] = array_merge((array) $original_value[$filekey] ?? [], is_array($processed_metadata[$filekey]) ? $processed_metadata[$filekey] : []);
+                      }
+                    }
+                  }
+                  // This will preserve existing Node Keys/values/mappings
+                  foreach ($original_node_mappings as $nodekey) {
+                    if (!in_array($nodekey, $processed_metadata['ap:entitymapping']['entity:node'])) {
+                      $processed_metadata[$nodekey] = $original_value[$nodekey] ?? [];
+                      $processed_metadata['ap:entitymapping']['entity:node'][] = $nodekey;
+                    }
+                    // No old Node-to-Node relationships is preserved if the processed data contains an already mapped key
+                  }
+                  // Really not needed?
+                  $processed_metadata['ap:entitymapping']['entity:node'] = array_unique($processed_metadata['ap:entitymapping']['entity:node'] ?? []);
+                  $processed_metadata['ap:entitymapping']['entity:file'] = array_unique($processed_metadata['ap:entitymapping']['entity:file'] ?? []);
+
+                  // Copy directly all as:mediatype into the child, the File Persistent Event will clean this up if redundant.
+                  // THIS MEANS WE DO NOT ALLOW AS:FILETYPES OVERRIDES!!! (SO HAPPY)
+                  // @TODO: DOCUMENT THIS!
+                  foreach (StrawberryfieldJsonHelper::AS_FILE_TYPE as $as_file_type) {
+                    if (isset($original_value[$as_file_type])) {
+                      $processed_metadata[$as_file_type] = $original_value[$as_file_type];
+                    }
+                  }
+                  // Now deal with Update modes.
+                  if ($op_secondary == 'replace') {
+                    $processed_metadata_keys = array_keys($processed_metadata);
+                    // We want to avoid replacing File keys.if
+                    if (isset($data->info['ops_safefiles']) && $data->info['ops_safefiles']) {
+                      // This will exclude all keys that contained files initially.
+                      // Making touching/deleting files basically impossible.
+                      $processed_metadata_keys = array_diff($processed_metadata_keys, $original_file_mappings);
+                    }
+
+                    foreach ($processed_metadata_keys as $processed_metadata_key) {
+                      $original_value[$processed_metadata_key] = $processed_metadata[$processed_metadata_key];
+                    }
+                    $processed_metadata = $original_value;
+                  }
+                  //@TODO. Since we are previewing, maybe on Updates we SHOULD always show to the end user this patch?
+                  if (isset($data->info['log_jsonpatch']) && $data->info['log_jsonpatch']) {
+                    $this->patchJson($original_value ?? [], $processed_metadata ?? [], TRUE);
+                  }
+
+                  if ($op_secondary == 'append') {
+                    $processed_metadata_keys = array_keys($processed_metadata);
+                    // We will exclude a bunch of keys from appending since
+                    // we already did a smart-ish processing moving them to
+                    // processed_metadata
+                    /* @TODO remove this once PHP 7 is deprecated
+                     * // Symfony\Polyfill\Php80 alread implements somthing similar.
+                     */
+                    if (!function_exists('str_starts_with')) {
+                      function str_starts_with($haystack, $needle) {
+                        return (string) $needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0;
+                      }
+                    }
+                    // New in 0.9.0. Also protect "label" and "type" those are always strings.
+                    // We should never add to them.
+                    $contract_keys = array_filter($processed_metadata_keys, function($value) {
+                      return (
+                        str_starts_with($value, "as:") ||
+                        str_starts_with($value, "ap:") ||
+                        $value == "label" ||
+                        $value == "type"
+                      );
+                    }
+                    );
+                    $processed_metadata_keys = array_diff($processed_metadata_keys, $contract_keys);
+                    function _update_append_array_unique_multidimensional($input) {
+                      $serialized = array_map('serialize', $input);
+                      $unique = array_unique($serialized);
+                      return array_intersect_key($input, $unique);
+                    }
+
+                    foreach ($processed_metadata_keys as $processed_metadata_key) {
+                      if (isset($original_value[$processed_metadata_key])) {
+                        // Only make array out of non arrays.
+                        if (!is_array($processed_metadata[$processed_metadata_key])) {
+                          $new = [$processed_metadata[$processed_metadata_key]];
+                        }
+                        else {
+                          $new = $processed_metadata[$processed_metadata_key];
+                        }
+                        if (!is_array($original_value[$processed_metadata_key])) {
+                          $old = [$original_value[$processed_metadata_key]];
+                        }
+                        else {
+                          $old = $original_value[$processed_metadata_key];
+                        }
+                        if (!StrawberryfieldJsonHelper::arrayIsMultiSimple($old) && !StrawberryfieldJsonHelper::arrayIsMultiSimple($new)) {
+                          // Both are numeric indexed arrays.
+                          $original_value[$processed_metadata_key] = [
+                            ...$old,
+                            ...$new
+                          ];
+                          $original_value[$processed_metadata_key] = _update_append_array_unique_multidimensional($original_value[$processed_metadata_key]);
+                        }
+                        else {
+                          if (StrawberryfieldJsonHelper::arrayIsMultiSimple($old) && StrawberryfieldJsonHelper::arrayIsMultiSimple($new)) {
+                            $original_value[$processed_metadata_key] = $old + $new;
+                          }
+                          else {
+                            if (StrawberryfieldJsonHelper::arrayIsMultiSimple($old) && !StrawberryfieldJsonHelper::arrayIsMultiSimple($new)) {
+                              $original_value[$processed_metadata_key] = [
+                                ...[$old],
+                                ...$new
+                              ];
+                              $original_value[$processed_metadata_key] = _update_append_array_unique_multidimensional($original_value[$processed_metadata_key]);
+                            }
+                            else {
+                              if (!StrawberryfieldJsonHelper::arrayIsMultiSimple($old) && StrawberryfieldJsonHelper::arrayIsMultiSimple($new)) {
+                                $original_value[$processed_metadata_key] = [
+                                  ...$old,
+                                  ...[$new]
+                                ];
+                                $original_value[$processed_metadata_key] = _update_append_array_unique_multidimensional($original_value[$processed_metadata_key]);
+                              }
+                            }
+                          }
+                        }
+                      }
+                      else {
+                        $original_value[$processed_metadata_key] = $processed_metadata[$processed_metadata_key];
+                      }
+                    }
+                    // Copy over our contract keys.
+                    foreach ($contract_keys as $contract_key) {
+                      $original_value[$contract_key] = $processed_metadata[$contract_key];
+                      // Keep memory footprint lower?
+                      unset($processed_metadata[$contract_key]);
+                    }
+                    $processed_metadata = $original_value;
+                  }
+
+                  // Now deal again with ap:tasks only if the replace/append operation stripped the basics out
+
+                  if (isset($processed_metadata['ap:tasks']) && is_array($processed_metadata['ap:tasks'])) {
+                    // basically reuse what is there (which at this stage will be a mix of original data and new or default to the $sort file defined before
+                    $processed_metadata['ap:tasks']['ap:sortfiles'] = $processed_metadata['ap:tasks']['ap:sortfiles'] ?? $sort_files;
+                  }
+                  else {
+                    // Only set if after all the options it was removed at all.
+                    $processed_metadata['ap:tasks'] = [];
+                    $processed_metadata['ap:tasks']['ap:sortfiles'] = $sort_files;
+                  }
+
+                  $itemfield->setMainValueFromArray($processed_metadata);
+                  break;
+                }
+              }
+            }
+            else {
+              // if the Saved one is empty use the new always.
+              // Applies to Patch/Update.
+              $field->setValue($jsonstring);
+            }
+            if ($node->getEntityType()->isRevisionable()) {
+              // Forces a New Revision for Not-create Operations.
+              $node->setNewRevision(TRUE);
+              $node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+              // Set data for the revision
+              $node->setRevisionLogMessage('ADO modified via AMI Set ' . $data->info['set_id']);
+              $node->setRevisionUserId($data->info['uid']);
+            }
+          }
+          // In case $status was not moderated.
+          if ($status) {
+            // Publish status keep is FALSE
+            if ($op == 'update' && $status_keep == FALSE) {
+              $node->setPublished();
+            }
+          }
+          elseif (!isset($nodeValues['moderation_state'])) {
+            // Only unpublish if not moderated and status keep is FALSE.
+            if ($op == 'update' && $status_keep == FALSE) {
+              $node->setUnpublished();
+            }
+          }
+
+          $message = $this->t('ADO %title  with UUID:@uuid on Set @setid would be @ophuman if no other warning/error exists.', [
+            '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+            '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+            '%title' => $label ?? 'Unnamed ADO',
+            '@ophuman' => $op == $op_original ? static::OP_HUMAN[$op] : static::OP_HUMAN[$op] . ' and ' . static::OP_HUMAN[$op_original]
+          ]);
+           $this->messenger->addStatus($message);
+          return $node ?? FALSE;
+        }
+        catch (\Throwable $exception) {
+          $message = $this->t('Sorry we did all right but we would fail to have the ADO with UUID @uuid on Set @setid to be @ophuman. Something went wrong with error @e. Please check your Drupal Logs and notify your admin.', [
+            '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+            '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+            '@ophuman' => $op == $op_original ? static::OP_HUMAN[$op] : static::OP_HUMAN[$op] . ' and ' . static::OP_HUMAN[$op_original],
+            '@e' => $exception->getMessage()
+          ]);
+           $this->messenger->addError($message);
+          return FALSE;
+        }
+      }
+      else {
+        $message = $this->t('Sorry we did all right but JSON resulting at the end is flawed and we would fail to have the ADO with UUID @uuid on Set @setid to be @ophuman. This is quite strange. Please check your Drupal Logs and notify your admin.', [
+          '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+          '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+          '@ophuman' => $op == $op_original ? static::OP_HUMAN[$op] : static::OP_HUMAN[$op] . ' and ' . static::OP_HUMAN[$op_original]
+        ]);
+         $this->messenger->addError($message);
+        return FALSE;
+      }
+    }
+    catch (\Throwable $exception) {
+      $message = $this->t('Sorry, something failed badly at a last stage and we would fail to have the ADO with UUID @uuid on Set @setid to be @ophuman with error @error. This is quite strange. Please check your Drupal Logs and notify your admin.', [
+        '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+        '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+        '@ophuman' => $op == $op_original ? (static::OP_HUMAN[$op] ?? "Undefined operation") : (static::OP_HUMAN[$op] ?? "Undefined operation"). ' and ' . (static::OP_HUMAN[$op_original] ?? "Undefined operation"),
+        '@error' => $exception->getMessage(),
+      ]);
+       $this->messenger->addError($message);
+      return FALSE;
+    }
+  }
+
+  /**
+   * Will return a Patched array using on original/new arrays.
+   *
+   * @param array $original
+   * @param array $new
+   *
+   * @param bool $reverse
+   *     If true we will generate an UNDO patch
+   *
+   * @return false|string
+   */
+  protected function patchJson(array $original, array $new, $reverse = FALSE) {
+    // IMPORTANT:
+    // We need to Object-it-fy here to make sure that
+    // the patch generated is Object properties aware
+    // Instead of an associative Array of arrays (which fails)
+    $original = json_decode(json_encode($original));
+    $new = json_decode(json_encode($new));
+    //@TODO bring this back when we add extra patch update flags
+    // JsonDiff can only work with Arrays that do not contain Objects as values.
+    // @throws \Swaggest\JsonDiff\Exception
+    try {
+      if ($reverse) {
+        $r = new JsonDiff(
+          $original,
+          $new,
+          JsonDiff::SKIP_JSON_MERGE_PATCH + JsonDiff::COLLECT_MODIFIED_DIFF
+        );
+      }
+      else {
+        $r = new JsonDiff(
+          $new,
+          $original,
+          JsonDiff::SKIP_JSON_MERGE_PATCH + JsonDiff::COLLECT_MODIFIED_DIFF
+        );
+      }
+      $patch = $r->getPatch()->jsonSerialize();
+    }
+    catch (\Swaggest\JsonDiff\Exception $exception) {
+      // We do not want to make ingesting slower. Just return [];
+      return '{}';
+    }
+    return json_encode($patch ?? []);
+  }
+
+  /**
+   * Processes a File and technical metadata to avoid congestion.
+   *
+   * @param mixed $data
+   *
+   */
+  protected function checkFileAvailability($data) {
+    try {
+      $zip_file_id = is_object($data->info['zip_file']) && $data->info['zip_file'] instanceof FileInterface ? (string) $data->info['zip_file']->id() : '0';
+      $file_exists = $this->AmiUtilityService->file_check_availability(trim($data->info['filename'] ?? ''),
+        $data->info['zip_file'], $data->info['force_file_process']);
+      if ($file_exists) {
+        $message = $this->t('The referenced file @filename from Set @setid was found!',
+          [
+            '@setid' => $data->info['set_id'] ?? 'Unknown Set',
+            '@filename' => $data->info['filename']
+          ]);
+        $this->messenger->addStatus($message);
+        return TRUE;
+      }
+      else {
+        $message = $this->t('Ups. The referenced file @filename from Set @setid could not be found.',
+          [
+            '@setid' => $data->info['set_id'] ?? 'Unknown Set',
+            '@filename' => $data->info['filename']
+          ]);
+         $this->messenger->addError($message);
+        return FALSE;
+      }
+    }
+    catch (\Throwable $e) {
+      $message = $this->t('Processing File @filename from Set @setid failed with unexpected error @error. Giving up.',
+        [
+          '@setid' => $data->info['set_id'] ?? 'Unknown Set',
+          '@filename' => $data->info['filename'],
+          '@error' => $e->getMessage(),
+        ]);
+       $this->messenger->addError($message);
+      return FALSE;
+    }
+  }
+
+  /**
+   * Processes a CSV File without technical metadata. This is just for the purpose of input for the CSV queue worker
+   *
+   * @param mixed $data
+   */
+  protected function processCSvFile($data): EntityInterface|File|null {
+    if (!($data->info['csv_filename'] ?? NULL)) {
+      return NULL;
+    }
+    $file = $this->AmiUtilityService->file_get(trim($data->info['csv_filename']),
+      $data->info['zip_file'] ?? NULL, TRUE);
+    if ($file) {
+      $event_type = StrawberryfieldEventType::TEMP_FILE_CREATION;
+      $current_timestamp = (new DrupalDateTime())->getTimestamp();
+      $event = new StrawberryfieldFileEvent($event_type, 'ami', $file->getFileUri(), $current_timestamp);
+      // This will allow the extracted CSV from the zip to be composted, even if it was not a CSV.
+      // IN a queue by \Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventCompostBinSubscriber
+      $this->eventDispatcher->dispatch($event, $event_type);
+    }
+    if ($file && $file->getMimeType() == 'text/csv') {
+      return $file;
+    }
+    else {
+      $message = $this->t('The referenced nested CSV @filename on row id @rowid from Set @setid could not be found or had the wrong format. Skipping',
+        [
+          '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+          '@filename' => $data->info['csv_filename'],
+          '@rowid' => $data->info['row']['row_id'] ?? '0',
+        ]);
+      $this->loggerFactory->get('ami_file')->warning($message ,[
+        'setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+        'time_submitted' => $data->info['time_submitted'] ?? '',
+      ]);
+      return NULL;
+    }
+  }
+
+
+  /**
+   * Checks if processing can be done, so we can bail out sooner.
+   *
+   * @param $data
+   *
+   * @return bool|null
+   *    FALSE if can not, TRUE if it can, NULL if it is "create" but already there allowing further processing if needed.
+   */
+  private function canProcess($data): bool|null {
+
+    //OP can be one of
+    /*
+    'create' => 'Create New ADOs',
+    'update' => 'Update existing ADOs',
+    'patch' => 'Patch existing ADOs',
+    'delete' => 'Delete existing ADOs',
+    'sync' => 'Sync' with either create/update/delete as sub operation.
+    */
+    try {
+      $op = $data->pluginconfig->op ?? NULL;
+      if ($data->pluginconfig->op == 'sync') {
+        // We relay on the CSV expander to set this correctly
+        // We always default to create. Worst case scenario it will
+        // fail bc we can't if already there
+        $op = $data->info['op_secondary'] ?? 'create';
+        $op = in_array($op, ['create', 'update', 'delete']) ? $op : NULL;
+      }
+
+      /** @var \Drupal\Core\Entity\ContentEntityInterface[] $existing */
+      $existing = $this->entityTypeManager->getStorage('node')
+        ->loadByProperties(
+          ['uuid' => $data->info['row']['uuid']]
+        );
+
+      if (count($existing) && $op === 'create') {
+        $message = $this->t('Sorry, you requested an ADO with UUID @uuid to be created via Set @setid. But there is already one in your repo with that UUID. So we would skip this ADO.', [
+          '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+          '@setid' => $data->info['set_id']
+        ]);
+         $this->messenger->addWarning($message);
+
+        return NULL;
+      }
+      elseif (!count($existing) && $op !== 'create') {
+        $message = $this->t('Sorry, the ADO with UUID @uuid you requested to be @ophuman via Set @setid does not exist. So we would skip this ADO.', [
+          '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+          '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+          '@ophuman' => static::OP_HUMAN[$op],
+        ]);
+        
+         $this->messenger->addWarning($message);
+        return FALSE;
+      }
+      $account = $data->info['uid'] == \Drupal::currentUser()
+        ->id() ? \Drupal::currentUser() : $this->entityTypeManager->getStorage('user')
+        ->load($data->info['uid']);
+
+      if ($op !== 'create' && $account && $existing && count($existing) == 1) {
+        $existing_object = reset($existing);
+        if (!$existing_object->access('update', $account)) {
+          $message = $this->t('Sorry you have no system permission to @ophuman ADO with UUID @uuid via Set @setid. So we would skip this ADO.', [
+            '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+            '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+            '@ophuman' => static::OP_HUMAN[$op],
+          ]);
+           $this->messenger->addWarning($message);
+          return FALSE;
+        }
+      }
+      return TRUE;
+    }
+    catch (\Throwable $e) {
+      $message = $this->t('Sorry. @ophuman ADO with UUID @uuid via Set @setid could not be validated because of an unexpected error @error. So we would skip this ADO.', [
+        '@uuid' => $data->info['row']['uuid'] ?? 'Undefined UUID',
+        '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+        '@ophuman' => static::OP_HUMAN[$op],
+        '@error' => $e->getMessage()
+      ]);
+       $this->messenger->addError($message);
+
+      return FALSE;
+    }
+  }
+
+  /**
+   * Sets AMI set processing status
+   *
+   * @param string    $status
+   * @param \stdClass $data
+   */
+  protected function setStatus(string $status, \stdClass $data): void {
+    try {
+      $set_id = $data->info['set_id'] ?? NULL;
+      if (!empty($set_id)) {
+        $processed_set_status = $this->statusStore->get('set_' . $set_id);
+        $processed_set_status['processed'] = $processed_set_status['processed'] ?? 0;
+        $processed_set_status['errored'] = $processed_set_status['errored'] ?? 0;
+        $processed_set_status['total'] = $processed_set_status['total'] ?? 0;
+        if ($status != amiSetEntity::STATUS_PROCESSING) {
+          $processed_set_status['errored'] = $processed_set_status['errored']
+            + 1;
+        }
+        else {
+          $processed_set_status['processed'] = $processed_set_status['processed'] + 1;
+        }
+        $this->statusStore->set('set_' . $set_id, $processed_set_status);
+
+        $sofar = $processed_set_status['processed'] + $processed_set_status['errored'];
+        $finished = ($sofar >= $processed_set_status['total']);
+
+        $ami_set = $this->entityTypeManager->getStorage('ami_set_entity')
+          ->load($set_id);
+        // Means the AMI set is gone.
+        if (!$ami_set) {
+          $message = $this->t('The original AMI Set ID @setid does not longer exist. Last known status was: @status ',[
+            '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+            '@status' => $status ?? 'Unknown',
+          ]);
+          $this->loggerFactory->get('ami')->warning($message ,[
+            'setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+            'time_submitted' => $data->info['time_submitted'] ?? '',
+          ]);
+        }
+        else {
+          if ($ami_set->getStatus() != $status
+            && $status != amiSetEntity::STATUS_PROCESSING
+            && !$finished
+          ) {
+            $ami_set->setStatus(
+              $status
+            );
+            $ami_set->save();
+          }
+          elseif ($finished) {
+            if ($processed_set_status['errored'] == 0) {
+              $ami_set->setStatus(
+                amiSetEntity::STATUS_PROCESSED
+              );
+            }
+            elseif ($processed_set_status['errored']
+              == $processed_set_status['total']
+            ) {
+              $ami_set->setStatus(
+                amiSetEntity::STATUS_FAILED
+              );
+            }
+            else {
+              $ami_set->setStatus(
+                amiSetEntity::STATUS_PROCESSED_WITH_ERRORS
+              );
+            }
+            $ami_set->save();
+          }
+        }
+      }
+      else {
+        throw new \Exception("Can't set status for AMI set if no Set ID is present in the Queue item's data. Did you generate this item manually?");
+      }
+    }
+    catch (\Throwable $exception)  {
+      $message = $this->t('The original AMI Set ID @setid does not longer exist or some other error happened while setting the status: @e.',[
+        '@setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+        '@e' => $exception->getMessage(),
+      ]);
+      // Makes no sense to log to the AMI file logger anymore?
+      // Send to the global ami logger (DB)
+      $this->loggerFactory->get('ami')->warning($message ,[
+        'setid' => $data->info['set_id'] ?? 'Undefined AMI set ID',
+        'time_submitted' => $data->info['time_submitted'] ?? '',
+      ]);
+    }
+  }
+
+
+  private function processAdoDiff(ContentEntityInterface $ado, bool $compare = FALSE):array {
+    // Because we are under AJAX and deprecations (Drupal 11 +) could
+    // trigger a throwable, we need to ignore those
+    set_error_handler(function ($errno, $errstr) {
+      // Ignore deprecations
+      if ($errno === E_DEPRECATED || $errno === E_USER_DEPRECATED) {
+        return true; // Return true tells PHP the error was handled internally
+      }
+      return false; // Pass other errors to standard PHP error handlers
+    });
+    $render_array = [];
+
+
+
+    $uuid = $ado->uuid();
+    $viewBuilder = \Drupal::entityTypeManager()->getViewBuilder('node');
+    $view_mode = \Drupal::service('format_strawberryfield.view_mode_resolver')->get($ado);
+    $view_mode_link = Link::createFromRoute($this->t('@entity_view_display_label',['@entity_view_display_label' => $view_mode]),
+      "entity.entity_view_display.node.view_mode",
+      [
+        'entity_type_id' => 'node',
+        'node_type' => $ado->bundle(),
+        'view_mode_name' => $view_mode
+      ],
+      [
+        'attributes' => [
+          'target' => '_blank',
+          'rel' => 'noopener noreferrer',
+        ]
+      ]);
+
+
+
+    $ado->preview_view_mode = $view_mode;
+    $ado->in_preview = TRUE;
+    $build = NULL;
+    try {
+      $build_array = $viewBuilder->view($ado, $view_mode);
+      unset($build_array['#cache']);
+      $errored = FALSE;
+      $context = new RenderContext();
+      $build = $this->renderer->executeInRenderContext($context, function() use ($build_array) {
+        return $this->renderer->render($build_array);
+      });
+
+      if (!$context->isEmpty()) {
+        // Bubbled metadata is captured inside $context instead of crashing the site
+        $bubbleable_metadata = $context->pop();
+      }
+      $build =  (string) $build;
+      $render_array['preview']['#markup'] = $build;
+      $render_array['preview']['#type']= 'container';
+      $render_array['preview']['#attributes']['id'] = 'ami-preview-container-ado';
+    }
+    catch (\Throwable $e) {
+      $errored = TRUE;
+      $messages = '';
+      while ($e !== null) {
+        $messages = $messages . '<p><em>'.$e->getMessage().'</em></p>';
+        $e = $e->getPrevious();
+      }
+      $messages = $messages."<p>Most likely a twig template used in your View Mode is calling a native/drupal extension on invalid data provided by the previewed CSV Row/Future ADO. This does not mean the ADO won't be processed but will for sure FAIL rendering to end users. Please review your Drupal logs and any display time Metadata Display Entities (Twig Templates) used to render ADOs of this type.</p>";
+      $view_mode_link_renderable = $view_mode_link->toRenderable();
+      $view_mode_link_rendered = $this->renderer->renderInIsolation($view_mode_link_renderable);
+      $messages = new FormattableMarkup($messages,[]);
+      $render_array['error']['#markup'] = $this->t("<h3>Rendering Error on view mode <em>@link</em> with message:</h3><div>@messages</div>",
+        [
+          '@link' =>  new FormattableMarkup($view_mode_link_rendered, []),
+          '@messages' => $messages
+        ],
+      );
+    }
+
+
+    if ($compare && $build && !$errored) {
+      $errored_existing = FALSE;
+      $build_existing = NULL;
+      $exists_in_storage = $this->entityTypeManager->getStorage('node')->loadByProperties(['uuid'=> $uuid]);
+      if (!empty($exists_in_storage)) {
+        $existing_ado = reset($exists_in_storage);
+        $view_mode = \Drupal::service('format_strawberryfield.view_mode_resolver')->get($existing_ado);
+        $build_existing = $viewBuilder->view($existing_ado, $view_mode);
+        unset($build_existing['#cache']);
+        try {
+          $context = new RenderContext();
+          $build_existing = $this->renderer->executeInRenderContext($context, function() use ($build_existing) {
+            return $this->renderer->render($build_existing);
+          });
+
+          if (!$context->isEmpty()) {
+            // Bubbled metadata is captured inside $context instead of crashing the site
+            $bubbleable_metadata = $context->pop();
+          }
+          $build_existing = (string) $build_existing;
+        }
+        catch (\Throwable $e) {
+          $view_mode_existing = \Drupal::service('format_strawberryfield.view_mode_resolver')->get($existing_ado);
+          $view_mode_link_existing = Link::createFromRoute($this->t('@entity_view_display_label',['@entity_view_display_label' => $view_mode_existing]),
+            "entity.entity_view_display.node.view_mode",
+            [
+              'entity_type_id' => 'node',
+              'node_type' => $existing_ado->bundle(),
+              'view_mode_name' => $view_mode_existing
+            ],
+            [
+              'attributes' => [
+                'target' => '_blank',
+                'rel' => 'noopener noreferrer',
+              ]
+            ]);
+          $errored_existing = TRUE;
+          $messages = '';
+          while ($e !== null) {
+            $messages = $messages . '<p><em>'.$e->getMessage().'</em></p>';
+            $e = $e->getPrevious();
+          }
+          $messages = $messages."<p>Most likely a twig template used in your View Mode is calling a native/drupal extension on invalid data provided by the existing ADO matching the UUID provided in your preview ROW</p>.<p> Please review this AMI Set Settings, Drupal logs and any display time Metadata Display Entities (Twig Templates) used to render ADOs of this type.</p>";
+          $view_mode_link_renderable = $view_mode_link_existing->toRenderable();
+          $view_mode_link_rendered = $this->renderer->renderInIsolation($view_mode_link_renderable);
+          $messages = new FormattableMarkup($messages,[]);
+          $render_array['error_existing']['#markup'] = $this->t("<h3>Rendering Error on Existing ADO on view mode <em>@link</em> with message:</h3><div>@messages</div>",
+            [
+              '@link' => new FormattableMarkup($view_mode_link_rendered,[]),
+              '@messages' => $messages
+            ],
+          );
+        }
+        if ($build_existing) {
+          // renderer class name:
+          //     Text renderers: Context, JsonText, Unified
+          //     HTML renderers: Combined, Inline, JsonHtml, SideBySide
+          $rendererName = 'SideBySide';
+
+          // the Differ options
+          $differOptions = new DifferOptions(
+          // show how many neighbor lines; Differ::CONTEXT_ALL shows the whole file
+            context: 3,
+            // ignore case difference
+            ignoreCase: false,
+            // ignore line ending difference
+            ignoreLineEnding: true,
+            // ignore whitespace difference
+            ignoreWhitespace: false,
+            // if the input sequence is too long, give up (especially for char-level diff)
+            lengthLimit: 2000,
+            // when inputs are identical, render the whole content rather than an empty result
+            fullContextIfIdentical: true,
+          );
+
+          // the renderer options
+          $rendererOptions = new RendererOptions(
+          // how detailed the rendered HTML in-line diff is? (none, line, word, char)
+            detailLevel: 'word',
+            // renderer language: eng, cht, chs, jpn, ...
+            // or an array which has the same keys with a language file
+            // check the "Custom Language" section in the readme for more advanced usage
+            language: 'eng',
+            // show line numbers in HTML renderers
+            lineNumbers: true,
+            // show a separator between different diff hunks in HTML renderers
+            separateBlock: true,
+            // show the (table) header
+            showHeader: true,
+            // render spaces/tabs as <span class="ch sp"> </span> tags (visualised via CSS)
+            spaceToHtmlTag: false,
+            // convert consecutive spaces to &nbsp; in HTML output
+            spacesToNbsp: false,
+            // HTML renderer tab width (negative = do not convert into spaces)
+            tabSize: 4,
+            // Combined renderer: merge replace-blocks whose changed ratio is at or below this threshold (0–1)
+            mergeThreshold: 0.8,
+            // Unified/Context renderers CLI colorization:
+            // RendererConstant::CLI_COLOR_AUTO   = colorize if possible (default)
+            // RendererConstant::CLI_COLOR_ENABLE = force colorize
+            // RendererConstant::CLI_COLOR_DISABLE = force no color
+            cliColorization: -1,
+            // JSON renderer: emit op tags as human-readable strings instead of ints
+            outputTagAsString: false,
+            // JSON renderer: flags passed to json_encode()
+            // see https://www.php.net/manual/en/function.json-encode.php
+            jsonEncodeFlags: \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
+            // word-level diff: adjacent segments joined by these characters are merged into one
+            // e.g. "<del>good</del>-<del>looking</del>" → "<del>good-looking</del>"
+            wordGlues: ['-', ' '],
+            // return this string verbatim when the two inputs are identical; null = renderer default
+            resultForIdenticals: null,
+            // extra CSS classes added to the diff container <div> in HTML renderers
+            wrapperClasses: ['diff-wrapper'],
+          );
+          $jsonResult = DiffHelper::calculate($build_existing, $build, 'Json'); // may store the JSON result in your database
+          $htmlRenderer = RendererFactory::make($rendererName, $rendererOptions);
+          $result = $htmlRenderer->renderArray(json_decode($jsonResult, true));
+          $render_array['preview']['#attributes']['id'] = 'ami-preview-container-ado';
+          $render_array['preview']['#markup'] = $result;
+        }
+      }
+    }
+    return $render_array;
+  }
+
+}
+
+

--- a/src/Controller/AmiRowAutocompleteHandler.php
+++ b/src/Controller/AmiRowAutocompleteHandler.php
@@ -213,10 +213,12 @@ class AmiRowAutocompleteHandler extends ControllerBase {
                 $labels = \Drupal::service('ami.utility')
                   ->getDifferentValuesfromColumnSplit($data_to_clean,
                     0);
-                if (empty($labels)) {
-                  $labels =  \Drupal::service('ami.utility')->getDifferentValuesfromColumnJSON($data_to_clean,
+                // New for 1.7.0/2.1.0 We process both. Strings and JSON. More expensive
+                // but also more precise.
+                $labels_from_json =  \Drupal::service('ami.utility')->getDifferentValuesfromColumnJSON($data_to_clean,
                     0);
-                }
+                $labels = array_unique(array_merge($labels, $labels_from_json));
+
                 foreach ($labels as $label) {
                   $lod_for_label = \Drupal::service('ami.lod')
                     ->getKeyValuePerAmiSet($label, $id);

--- a/src/Controller/AmiRowAutocompleteHandler.php
+++ b/src/Controller/AmiRowAutocompleteHandler.php
@@ -463,7 +463,7 @@ class AmiRowAutocompleteHandler extends ControllerBase {
         else {
           $message = !$file ? 'The AMI set has no CSV File. The AMI set is empty.': 'The AMI set has no data for chosen row. The AMI set is empty.';
           if (!empty($message)) {
-            $preview_error = MetadataDisplayForm::buildAjaxPreviewError($message);
+            $preview_error = MetadataDisplayForm::buildAjaxPreviewError($message, TRUE);
             $output['preview_error'] = $preview_error;
           }
           $response->addCommand(new OpenOffCanvasDialogCommand(t('Preview'), $output, ['width' => '50%']));

--- a/src/Entity/amiSetEntity.php
+++ b/src/Entity/amiSetEntity.php
@@ -147,6 +147,7 @@ class amiSetEntity extends ContentEntityBase implements amiSetEntityInterface {
 
 
   public const STATUS_READY = 'READY';
+  public const STATUS_NEEDS_REVIEW = 'NEEDS_REVIEW';
   public const STATUS_NOT_READY = 'NOT_READY';
   public const STATUS_PROCESSING = 'PROCESSING';
   public const STATUS_PROCESSED = 'PROCESSED';
@@ -166,6 +167,7 @@ class amiSetEntity extends ContentEntityBase implements amiSetEntityInterface {
     amiSetEntity::STATUS_PROCESSED_WITH_ERRORS => 'Processed with errors',
     amiSetEntity::STATUS_FAILED => 'Failed',
     amiSetEntity::STATUS_ENTITIES_DELETED => 'ADOs Deleted',
+    amiSetEntity::STATUS_NEEDS_REVIEW => 'CSV associated data needs review'
   ];
 
   /**

--- a/src/Form/amiSetEntityActionProcessedForm.php
+++ b/src/Form/amiSetEntityActionProcessedForm.php
@@ -92,9 +92,12 @@ class amiSetEntityActionProcessedForm extends ContentEntityConfirmFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $csv_file_reference = $this->entity->get('source_data')->getValue();
+    $file = NULL;
     if (isset($csv_file_reference[0]['target_id'])) {
       $file = $this->entityTypeManager->getStorage('file')->load($csv_file_reference[0]['target_id']);
     }
+
+
     $action_config = [];
     $pluginid = $form_state->getValue('ami_select_action') ?? NULL;
     if (!empty($pluginid)) {
@@ -201,6 +204,26 @@ class amiSetEntityActionProcessedForm extends ContentEntityConfirmFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    $csv_file_reference = $this->entity->get('source_data')->getValue();
+    $file = NULL;
+    if (isset($csv_file_reference[0]['target_id'])) {
+      $file = $this->entityTypeManager->getStorage('file')->load($csv_file_reference[0]['target_id']);
+    }
+    if (!$file) {
+      $form['status'] = [
+        '#tree' => TRUE,
+        '#type' => 'fieldset',
+        '#title' =>  $this->t(
+          'Error'
+        ),
+        '#markup' => $this->t(
+          'Sorry. This AMI set has no Source CSV attached and thus can not be used for Actions. Please edit this AMI set and add a CSV with your source data, having at least the same mapped columns present in your configuration and also proper UUIDs for each row (normally under a <em>node_uuid<em> column, if not manually overriden).'
+        ),
+      ];
+      return $form;
+    }
+
+
     $form['#prefix'] = '<div id="action-ajax-container">';
     $form['#suffix'] = '</div>';
     $data = new \stdClass();

--- a/src/Form/amiSetEntityDeleteProcessedForm.php
+++ b/src/Form/amiSetEntityDeleteProcessedForm.php
@@ -220,6 +220,27 @@ class amiSetEntityDeleteProcessedForm extends ContentEntityConfirmFormBase {
         );
         return $form;
       }
+      $csv_file_reference = $this->entity->get('source_data')->getValue();
+      $file = NULL;
+      if (isset($csv_file_reference[0]['target_id'])) {
+        $file = $this->entityTypeManager->getStorage('file')->load($csv_file_reference[0]['target_id']);
+      }
+      if (!$file) {
+        $form = $form + parent::buildForm($form, $form_state);
+        $form['actions']['submit']['#access'] = FALSE;
+        $form['description'] = [
+          '#tree' => TRUE,
+          '#type' => 'fieldset',
+          '#title' =>  $this->t(
+            'Error'
+          ),
+          '#markup' => $this->t(
+            'Sorry. This AMI set has no Source CSV attached and thus can not be used to delete ingested entities. Please edit this AMI set and add a CSV with your source data, having at least the same mapped columns present in your configuration and also proper UUIDs for each row (normally under a <em>node_uuid<em> column, if not manually overriden).'
+          ),
+        ];
+        return $form;
+      }
+
       $form['delete_enqueued'] = [
         '#type' => 'fieldset',
         '#title' => $this->t('Delete Ingested ADOs via this Set'),

--- a/src/Form/amiSetEntityProcessForm.php
+++ b/src/Form/amiSetEntityProcessForm.php
@@ -447,6 +447,20 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
         );
       }
 
+      if (!$file) {
+        $form['status'] = [
+          '#tree' => TRUE,
+          '#type' => 'fieldset',
+          '#title' =>  $this->t(
+            'Error'
+          ),
+          '#markup' => $this->t(
+            'Sorry. This AMI set has no Source CSV attached and thus can not be processed. Please edit this AMI set and add a CSV with your source data, having at least the same mapped columns present in your configuration and also proper UUIDs for each row (normally under a <em>node_uuid<em> column, if not manually overriden).'
+          ),
+        ];
+        return $form;
+      }
+
       // we can't assume the user did not mess with the AMI set data?
       $op = $data->pluginconfig->op ?? NULL;
       $ops = [
@@ -622,6 +636,7 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
         unset($form['status_keep']);
         return $form;
       }
+
       $notprocessnow = $form_state->getValue('not_process_now', NULL);
 
       $form['not_process_now'] = [
@@ -668,76 +683,73 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
         '#default_value' => FALSE,
       ];
       $rows = 0;
-      if ($file) {
-        $rows = $this->strawberryfieldUtility->csv_count($file);
-        $form['preview'] = [
-          '#type' => 'fieldset',
-          '#description' => $this->t('Preview will attempt to process a single ROW of this AMI set\'s CSV source data as it it would happen via a Queue Worker. Any referenced Files will be also validated to exists, but will not be downloaded/processed, which means also that your Preview might lack any `as:filetype` structure which will be reflected also when asking for a <em>diff</em> of the rendered version or the JSON. <br> That is by design and should be ignored.'),
-          '#states' => [
-            'visible' => [
-              ':input[name="preview_enabled"]' => ['checked' => TRUE],
-            ]
+
+      $rows = $this->strawberryfieldUtility->csv_count($file);
+      $form['preview'] = [
+        '#type' => 'fieldset',
+        '#description' => $this->t('Preview will attempt to process a single ROW of this AMI set\'s CSV source data as it it would happen via a Queue Worker. Any referenced Files will be also validated to exists, but will not be downloaded/processed, which means also that your Preview might lack any `as:filetype` structure which will be reflected also when asking for a <em>diff</em> of the rendered version or the JSON. <br> That is by design and should be ignored.'),
+        '#states' => [
+          'visible' => [
+            ':input[name="preview_enabled"]' => ['checked' => TRUE],
           ]
-        ];
-        $form['preview']['ado_amiset_preview_row'] = [
-          '#type' => 'textfield',
-          '#weight' => -8,
-          '#title' => t('Row to preview'),
-          '#description' => t('Your Source CSV has @count rows. Row 1 is the header and if used will always return row 2. You can also use the mapped "ADO label" column to autocomplete.', ['@count' => $rows]),
-          '#states' => [
-            'required' => [
-              ':input[name="preview_enabled"]' => ['checked' => TRUE],
-            ]
+        ]
+      ];
+      $form['preview']['ado_amiset_preview_row'] = [
+        '#type' => 'textfield',
+        '#weight' => -8,
+        '#title' => t('Row to preview'),
+        '#description' => t('Your Source CSV has @count rows. Row 1 is the header and if used will always return row 2. You can also use the mapped "ADO label" column to autocomplete.', ['@count' => $rows]),
+        '#states' => [
+          'required' => [
+            ':input[name="preview_enabled"]' => ['checked' => TRUE],
           ]
-        ];
+        ]
+      ];
 
-        $form['preview']['ado_amiset_row_context_preview']['#autocomplete_route_name'] = 'ami.rowsbylabel.autocomplete';
-        $form['preview']['ado_amiset_row_context_preview']['#autocomplete_route_parameters'] = [
-          'ami_set_entity' => $this->entity->id()
-        ];
+      $form['preview']['ado_amiset_row_context_preview']['#autocomplete_route_name'] = 'ami.rowsbylabel.autocomplete';
+      $form['preview']['ado_amiset_row_context_preview']['#autocomplete_route_parameters'] = [
+        'ami_set_entity' => $this->entity->id()
+      ];
 
-        $form['preview']['ado_amiset_preview_diff_rendered'] = [
-          '#type' => 'checkbox',
-          '#title' => $this->t('Preview Rendered as a diff'),
-          '#description' => $this->t(
-            'If the Row previewed references an existing ADO (via its UUID), then a DIFF of the HTML old v/s new one will be attempted. If the ADO is new no diff will be produced.'
-          ),
-          '#required' => FALSE,
-          '#default_value' => FALSE,
-        ];
-        $form['preview']['ado_amiset_preview_diff_json'] = [
-          '#type' => 'checkbox',
-          '#title' => $this->t('Preview JSON as a diff'),
-          '#description' => $this->t(
-            'If the Row previewed references an existing ADO (via its UUID), then a DIFF of the RAW JSON v/s new one will be attempted. If the ADO is new no diff will be produced.'
-          ),
-          '#required' => FALSE,
-          '#default_value' => FALSE,
-        ];
+      $form['preview']['ado_amiset_preview_diff_rendered'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Preview Rendered as a diff'),
+        '#description' => $this->t(
+          'If the Row previewed references an existing ADO (via its UUID), then a DIFF of the HTML old v/s new one will be attempted. If the ADO is new no diff will be produced.'
+        ),
+        '#required' => FALSE,
+        '#default_value' => FALSE,
+      ];
+      $form['preview']['ado_amiset_preview_diff_json'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Preview JSON as a diff'),
+        '#description' => $this->t(
+          'If the Row previewed references an existing ADO (via its UUID), then a DIFF of the RAW JSON v/s new one will be attempted. If the ADO is new no diff will be produced.'
+        ),
+        '#required' => FALSE,
+        '#default_value' => FALSE,
+      ];
 
-        $controller = \Drupal::service('class_resolver')
-          ->getInstanceFromDefinition('\Drupal\ami\Controller\AmiQueueWorkerPreviewHandler');
-        $form['preview']['button_preview_amiset'] = [
-          '#type' => 'button',
-          '#op' => 'preview',
-          '#button_type' => 'primary',
-          '#weight' => -7,
-          '#value' => t('Show preview for AMI Set'),
-          '#ajax' => [
-            'callback' => [$controller, 'simulateItemAjax'],
-          ],
-          '#attached' => [
-            'library' => ['core/drupal.dialog.ajax'],
-          ],
-          '#states' => [
-            'enabled' => [
-              ':input[name="ado_amiset_preview_row"]' => ['filled' => TRUE],
-            ]
+      $controller = \Drupal::service('class_resolver')
+        ->getInstanceFromDefinition('\Drupal\ami\Controller\AmiQueueWorkerPreviewHandler');
+      $form['preview']['button_preview_amiset'] = [
+        '#type' => 'button',
+        '#op' => 'preview',
+        '#button_type' => 'primary',
+        '#weight' => -7,
+        '#value' => t('Show preview for AMI Set'),
+        '#ajax' => [
+          'callback' => [$controller, 'simulateItemAjax'],
+        ],
+        '#attached' => [
+          'library' => ['core/drupal.dialog.ajax'],
+        ],
+        '#states' => [
+          'enabled' => [
+            ':input[name="ado_amiset_preview_row"]' => ['filled' => TRUE],
           ]
-        ];
-      }
-
-
+        ]
+      ];
     }
     return $form + parent::buildForm($form, $form_state);
   }

--- a/src/Form/amiSetEntityProcessForm.php
+++ b/src/Form/amiSetEntityProcessForm.php
@@ -681,9 +681,18 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
 
       $form['preview']['ado_amiset_preview_diff_rendered'] = [
         '#type' => 'checkbox',
-        '#title' => $this->t('Preview as a diff'),
+        '#title' => $this->t('Preview Rendered as a diff'),
         '#description' => $this->t(
           'If the Row previewed references an existing ADO (via its UUID), then a DIFF of the HTML old v/s new one will be attempted. If the ADO is new no diff will be produced.'
+        ),
+        '#required' => FALSE,
+        '#default_value' => FALSE,
+      ];
+      $form['preview']['ado_amiset_preview_diff_json'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Preview JSON as a diff'),
+        '#description' => $this->t(
+          'If the Row previewed references an existing ADO (via its UUID), then a DIFF of the RAW JSON v/s new one will be attempted. If the ADO is new no diff will be produced.'
         ),
         '#required' => FALSE,
         '#default_value' => FALSE,

--- a/src/Form/amiSetEntityProcessForm.php
+++ b/src/Form/amiSetEntityProcessForm.php
@@ -672,6 +672,7 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
         $rows = $this->strawberryfieldUtility->csv_count($file);
         $form['preview'] = [
           '#type' => 'fieldset',
+          '#description' => $this->t('Preview will attempt to process a single ROW of this AMI set\'s CSV source data as it it would happen via a Queue Worker. Any referenced Files will be also validated to exists, but will not be downloaded/processed, which means also that your Preview might lack any `as:filetype` structure which will be reflected also when asking for a <em>diff</em> of the rendered version or the JSON. <br> That is by design and should be ignored.'),
           '#states' => [
             'visible' => [
               ':input[name="preview_enabled"]' => ['checked' => TRUE],

--- a/src/Form/amiSetEntityProcessForm.php
+++ b/src/Form/amiSetEntityProcessForm.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\ContentEntityConfirmFormBase;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Drupal\ami\Entity\amiSetEntity;
@@ -657,70 +658,86 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
         '#required' => FALSE,
         '#default_value' => FALSE,
       ];
+
+      $form['preview_enabled'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t(
+          'Preview Instead of Processing'
+        ),
+        '#required' => FALSE,
+        '#default_value' => FALSE,
+      ];
       $rows = 0;
       if ($file) {
         $rows = $this->strawberryfieldUtility->csv_count($file);
-      }
-      $form['preview']['ado_amiset_preview_row'] = [
-        '#type' => 'textfield',
-        '#weight' => -8,
-        '#title' => t('Row to preview'),
-        '#description' => t('Your Source CSV has @count rows. Row 1 is the header and if used will always return row 2. You can also use the mapped "ADO label" column to autocomplete.', ['@count' => $rows]),
-        '#states' => [
-          'visible' => [
-            ':input[name="entity_type"]' => ['value' => 'ami'],
-            ':input[name="ado_amiset_preview"]' => ['filled' => true],
-          ],
-        ],
-      ];
+        $form['preview'] = [
+          '#type' => 'fieldset',
+          '#states' => [
+            'visible' => [
+              ':input[name="preview_enabled"]' => ['checked' => TRUE],
+            ]
+          ]
+        ];
+        $form['preview']['ado_amiset_preview_row'] = [
+          '#type' => 'textfield',
+          '#weight' => -8,
+          '#title' => t('Row to preview'),
+          '#description' => t('Your Source CSV has @count rows. Row 1 is the header and if used will always return row 2. You can also use the mapped "ADO label" column to autocomplete.', ['@count' => $rows]),
+          '#states' => [
+            'required' => [
+              ':input[name="preview_enabled"]' => ['checked' => TRUE],
+            ]
+          ]
+        ];
 
         $form['preview']['ado_amiset_row_context_preview']['#autocomplete_route_name'] = 'ami.rowsbylabel.autocomplete';
         $form['preview']['ado_amiset_row_context_preview']['#autocomplete_route_parameters'] = [
           'ami_set_entity' => $this->entity->id()
         ];
 
-      $form['preview']['ado_amiset_preview_diff_rendered'] = [
-        '#type' => 'checkbox',
-        '#title' => $this->t('Preview Rendered as a diff'),
-        '#description' => $this->t(
-          'If the Row previewed references an existing ADO (via its UUID), then a DIFF of the HTML old v/s new one will be attempted. If the ADO is new no diff will be produced.'
-        ),
-        '#required' => FALSE,
-        '#default_value' => FALSE,
-      ];
-      $form['preview']['ado_amiset_preview_diff_json'] = [
-        '#type' => 'checkbox',
-        '#title' => $this->t('Preview JSON as a diff'),
-        '#description' => $this->t(
-          'If the Row previewed references an existing ADO (via its UUID), then a DIFF of the RAW JSON v/s new one will be attempted. If the ADO is new no diff will be produced.'
-        ),
-        '#required' => FALSE,
-        '#default_value' => FALSE,
-      ];
+        $form['preview']['ado_amiset_preview_diff_rendered'] = [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Preview Rendered as a diff'),
+          '#description' => $this->t(
+            'If the Row previewed references an existing ADO (via its UUID), then a DIFF of the HTML old v/s new one will be attempted. If the ADO is new no diff will be produced.'
+          ),
+          '#required' => FALSE,
+          '#default_value' => FALSE,
+        ];
+        $form['preview']['ado_amiset_preview_diff_json'] = [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Preview JSON as a diff'),
+          '#description' => $this->t(
+            'If the Row previewed references an existing ADO (via its UUID), then a DIFF of the RAW JSON v/s new one will be attempted. If the ADO is new no diff will be produced.'
+          ),
+          '#required' => FALSE,
+          '#default_value' => FALSE,
+        ];
 
-      $form['preview']['button_preview'][
-      '#states'] = [
-        'visible' => [
-          ':input[name="ado_context_preview"]' => ['filled' => true],
-          ':input[name="entity_type"]' => ['value' => 'ado'],
-        ],
-      ];
-      $controller = \Drupal::service('class_resolver')->getInstanceFromDefinition('\Drupal\ami\Controller\AmiQueueWorkerPreviewHandler');
-      $form['preview']['button_preview_amiset'] = [
-        '#type' => 'button',
-        '#op' => 'preview',
-        '#weight' => -7,
-        '#value' => t('Show preview for AMI Set'),
-        '#ajax' => [
-          'callback' => [$controller, 'simulateItemAjax'],
-        ],
-        '#attached' => [
-          'library' => ['core/drupal.dialog.ajax'],
-        ],
-      ];
+        $controller = \Drupal::service('class_resolver')
+          ->getInstanceFromDefinition('\Drupal\ami\Controller\AmiQueueWorkerPreviewHandler');
+        $form['preview']['button_preview_amiset'] = [
+          '#type' => 'button',
+          '#op' => 'preview',
+          '#button_type' => 'primary',
+          '#weight' => -7,
+          '#value' => t('Show preview for AMI Set'),
+          '#ajax' => [
+            'callback' => [$controller, 'simulateItemAjax'],
+          ],
+          '#attached' => [
+            'library' => ['core/drupal.dialog.ajax'],
+          ],
+          '#states' => [
+            'enabled' => [
+              ':input[name="ado_amiset_preview_row"]' => ['filled' => TRUE],
+            ]
+          ]
+        ];
+      }
 
 
-  }
+    }
     return $form + parent::buildForm($form, $form_state);
   }
 
@@ -806,6 +823,45 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
           ],
         ],
       ];
+    }
+
+    return $element;
+  }
+
+  /**
+   * Returns the action form element for the current entity form.
+   */
+  protected function actionsElement(array $form, FormStateInterface $form_state) {
+    $element = $this->actions($form, $form_state);
+
+    if (isset($element['delete'])) {
+      // Move the delete action as last one, unless weights are explicitly
+      // provided.
+      $delete = $element['delete'];
+      unset($element['delete']);
+      $element['delete'] = $delete;
+      $element['delete']['#button_type'] = 'danger';
+    }
+
+    if (isset($element['submit'])) {
+      // Give the primary submit button a #button_type of primary.
+      $element['submit']['#button_type'] = 'primary';
+      $element['submit']['#states'] = [
+        'enabled' => [
+          ':input[name="preview_enabled"]' => ['checked' => FALSE],
+        ]
+      ];
+    }
+
+    $count = 0;
+    foreach (Element::children($element) as $action) {
+      $element[$action] += [
+        '#weight' => ++$count * 5,
+      ];
+    }
+
+    if (!empty($element)) {
+      $element['#type'] = 'actions';
     }
 
     return $element;

--- a/src/Form/amiSetEntityProcessForm.php
+++ b/src/Form/amiSetEntityProcessForm.php
@@ -11,6 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Drupal\ami\Entity\amiSetEntity;
+use Drupal\strawberryfield\StrawberryfieldUtilityService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -33,6 +34,14 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
   protected $statusStore;
 
   /**
+   * The Strawberry Field Utility Service.
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldUtilityService
+   */
+  protected $strawberryfieldUtility;
+
+
+  /**
    * Constructs a ContentEntityForm object.
    *
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
@@ -47,9 +56,14 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
   public function __construct(
     EntityRepositoryInterface $entity_repository,
     EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL,
-    TimeInterface $time = NULL, AmiUtilityService $ami_utility, PrivateTempStoreFactory $temp_store_factory) {
+    TimeInterface $time = NULL,
+    AmiUtilityService $ami_utility,
+    PrivateTempStoreFactory $temp_store_factory,
+    StrawberryfieldUtilityService $strawberryfield_utility_service,
+  ) {
     parent::__construct($entity_repository, $entity_type_bundle_info, $time);
     $this->AmiUtilityService = $ami_utility;
+    $this->strawberryfieldUtility = $strawberryfield_utility_service;
     $this->statusStore = $temp_store_factory->get('ami_queue_status');
   }
 
@@ -62,7 +76,8 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
       $container->get('entity_type.bundle.info'),
       $container->get('datetime.time'),
       $container->get('ami.utility'),
-      $container->get('tempstore.private')
+      $container->get('tempstore.private'),
+      $container->get('strawberryfield.utility')
     );
   }
 
@@ -421,6 +436,16 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
         $bundles[] = $data->mapping->globalmapping_settings->bundle ?? NULL;
       }
       $bundles = array_values(array_unique($bundles));
+
+      $csv_file_reference = $this->entity->get('source_data')->getValue();
+      $file = NULL;
+      if (isset($csv_file_reference[0]['target_id'])) {
+        /** @var \Drupal\file\Entity\File $file */
+        $file = $this->entityTypeManager->getStorage('file')->load(
+          $csv_file_reference[0]['target_id']
+        );
+      }
+
       // we can't assume the user did not mess with the AMI set data?
       $op = $data->pluginconfig->op ?? NULL;
       $ops = [
@@ -632,7 +657,61 @@ class amiSetEntityProcessForm extends ContentEntityConfirmFormBase {
         '#required' => FALSE,
         '#default_value' => FALSE,
       ];
-    }
+      $rows = 0;
+      if ($file) {
+        $rows = $this->strawberryfieldUtility->csv_count($file);
+      }
+      $form['preview']['ado_amiset_preview_row'] = [
+        '#type' => 'textfield',
+        '#weight' => -8,
+        '#title' => t('Row to preview'),
+        '#description' => t('Your Source CSV has @count rows. Row 1 is the header and if used will always return row 2. You can also use the mapped "ADO label" column to autocomplete.', ['@count' => $rows]),
+        '#states' => [
+          'visible' => [
+            ':input[name="entity_type"]' => ['value' => 'ami'],
+            ':input[name="ado_amiset_preview"]' => ['filled' => true],
+          ],
+        ],
+      ];
+
+        $form['preview']['ado_amiset_row_context_preview']['#autocomplete_route_name'] = 'ami.rowsbylabel.autocomplete';
+        $form['preview']['ado_amiset_row_context_preview']['#autocomplete_route_parameters'] = [
+          'ami_set_entity' => $this->entity->id()
+        ];
+
+      $form['preview']['ado_amiset_preview_diff_rendered'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Preview as a diff'),
+        '#description' => $this->t(
+          'If the Row previewed references an existing ADO (via its UUID), then a DIFF of the HTML old v/s new one will be attempted. If the ADO is new no diff will be produced.'
+        ),
+        '#required' => FALSE,
+        '#default_value' => FALSE,
+      ];
+
+      $form['preview']['button_preview'][
+      '#states'] = [
+        'visible' => [
+          ':input[name="ado_context_preview"]' => ['filled' => true],
+          ':input[name="entity_type"]' => ['value' => 'ado'],
+        ],
+      ];
+      $controller = \Drupal::service('class_resolver')->getInstanceFromDefinition('\Drupal\ami\Controller\AmiQueueWorkerPreviewHandler');
+      $form['preview']['button_preview_amiset'] = [
+        '#type' => 'button',
+        '#op' => 'preview',
+        '#weight' => -7,
+        '#value' => t('Show preview for AMI Set'),
+        '#ajax' => [
+          'callback' => [$controller, 'simulateItemAjax'],
+        ],
+        '#attached' => [
+          'library' => ['core/drupal.dialog.ajax'],
+        ],
+      ];
+
+
+  }
     return $form + parent::buildForm($form, $form_state);
   }
 

--- a/src/Form/amiSetEntityReconcileForm.php
+++ b/src/Form/amiSetEntityReconcileForm.php
@@ -258,7 +258,7 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
               '#title' => $this->t('Choose a Column to Preview'),
               '#options' => array_combine($source_options, $source_options),
               '#default_value' => $form_state->getValue(['lod_options','select_preview']),
-              '#description' => $this->t('We will attempt to fetch first cells holding a string of delimited values (by "|@|" or ";"). If no luck, and the selected column cell\'s holds a valid JSON, any simple lists of values (e.g ["pup","dog","canine"], and/or any property where the JSON key name contains one of the following strings: "label, value, name". Any URL/URN or URI will be not taken in account'),
+              '#description' => $this->t('We will attempt to fetch first cells holding a string of delimited values (by "|@|" or ";"). Additionally, if any selected column cell\'s holds a valid JSON, e.g. any simple lists of values (e.g ["pup","dog","canine"], and/or an object with any property where the JSON key name contains one of the following strings: "label, value, type, name". URL/URN or URI will be not taken in account.'),
             ];
             $form['lod_options']['preview'] = [
               '#type' => 'button',

--- a/src/Form/amiSetEntityReconcileForm.php
+++ b/src/Form/amiSetEntityReconcileForm.php
@@ -173,103 +173,118 @@ class amiSetEntityReconcileForm extends ContentEntityConfirmFormBase {
       ];
       $access = TRUE;
       $csv_file_reference = $this->entity->get('source_data')->getValue();
+      $file =  NULL;
       if (isset($csv_file_reference[0]['target_id'])) {
         /** @var \Drupal\file\Entity\File $file */
         $file = $this->entityTypeManager->getStorage('file')->load(
           $csv_file_reference[0]['target_id']
         );
-        if ($file) {
-          $file_data_all = $this->AmiUtilityService->csv_read($file);
-          $column_keys = $file_data_all['headers'] ?? [];
-          sort($column_keys, SORT_NATURAL);
+      }
+      if ($file) {
+        $file_data_all = $this->AmiUtilityService->csv_read($file);
+        $column_keys = $file_data_all['headers'] ?? [];
+        sort($column_keys, SORT_NATURAL);
 
-          $reconcile_column_settings = $form_state->getValue(['mapping', 'lod_columns'], NULL) ?? ($data->reconcileconfig->columns ?? []);
-          $reconcile_column_settings = (array) $reconcile_column_settings;
-          //@ TODO we should remove from settings columns not present in the Source Data.
-          // Forms state will do that automatically but i prefer that as a sanity check
-          $form['mapping']['lod_columns'] = [
-            '#type' => 'select',
-            '#title' => $this->t('Select which columns you want to reconcile against LoD providers'),
-            '#default_value' => $reconcile_column_settings,
-            '#options' => array_combine($column_keys, $column_keys),
-            '#size' => count($column_keys),
-            '#multiple' => TRUE,
-            '#description' => $this->t('Columns that contain data you want to reconcile against LoD providers'),
-            '#empty_option' => $this->t('- Please select columns -'),
-            '#ajax' => [
-              'callback' => [$this, 'lodOptionsAjaxCallback'],
-              'wrapper' => 'lod-options-wrapper',
-              'event' => 'change',
-            ],
-          ];
-          $form['lod_options'] = [
-            '#type' => 'hidden',
-            '#prefix' => '<div id="lod-options-wrapper">',
-            '#suffix' => '</div>',
-          ];
-          $saved_reconcile_mapping_settings = [];
-          if ($data->reconcileconfig->mappings ?? NULL) {
-            foreach ($data->reconcileconfig->mappings as $column => $mapping) {
-              $saved_reconcile_mapping_settings[md5($column)] = $mapping;
-            }
-          }
-
-          $reconcile_mapping_settings = $form_state->getValue(['lod_options', 'mappings'], NULL) ?? ($saved_reconcile_mapping_settings ?? NULL);
-          $reconcile_mapping_settings = (array) $reconcile_mapping_settings;
-
-          if ($reconcile_column_settings) {
-            $source_options = $reconcile_column_settings;
-            // We convert the values into its md5 representation, then flip
-            // This is because the webform_mapping element uses a value callback
-            // that converts form state values from Drupal Nested Arrays, which
-            // Parses ][  anything that looks like that, breaking e.g XML to CSV
-            // column headers with Xpaths.
-
-            foreach ($source_options as $key => &$value) {
-              $value = md5($value);
-            }
-            $source_options = array_flip($source_options);
-            $column_options = $this->AmiLoDService::AMI_FORM_EXPOSED_LOD_SOURCES;
-            // Fetch also Custom ones. The format will be "custom;the_custom_lod_entity_id"
-            $column_options = $column_options + $this->AmiLoDService->getCustomLoDEndpoints();
-            $form['lod_options']['#type'] = 'fieldset';
-            $form['lod_options']['#tree'] = TRUE;
-
-            $form['lod_options']['mappings'] = [
-              '#type' => 'webform_mapping',
-              '#title' => $this->t('LoD Sources'),
-              '#description' => $this->t(
-                'Please select how your chosen Columns will be LoD reconciled'
-              ),
-              '#description_display' => 'before',
-              '#empty_option' => $this->t('- Let AMI decide -'),
-              '#empty_value' => NULL,
-              '#default_value' => $reconcile_mapping_settings,
-              '#required' => TRUE,
-              '#destination__multiple' => TRUE,
-              '#source' => $source_options,
-              '#source__title' => $this->t('LoD reconcile options'),
-              '#destination__title' => $this->t('LoD Authority Sources'),
-              '#destination' => $column_options,
-              '#destination__size' => count($column_options),
-            ];
-            $form['lod_options']['select_preview'] = [
-              '#type' => 'select',
-              '#title' => $this->t('Choose a Column to Preview'),
-              '#options' => array_combine($source_options, $source_options),
-              '#default_value' => $form_state->getValue(['lod_options','select_preview']),
-              '#description' => $this->t('We will attempt to fetch first cells holding a string of delimited values (by "|@|" or ";"). Additionally, if any selected column cell\'s holds a valid JSON, e.g. any simple lists of values (e.g ["pup","dog","canine"], and/or an object with any property where the JSON key name contains one of the following strings: "label, value, type, name". URL/URN or URI will be not taken in account.'),
-            ];
-            $form['lod_options']['preview'] = [
-              '#type' => 'button',
-              '#op' => 'preview',
-              '#value' => $this->t('Inspect cleaned/split up/or JSON decoded column values'),
-              '#ajax' => [
-                'callback' => [$this, 'ajaxColumPreview'],
-              ],
-            ];
+        $reconcile_column_settings = $form_state->getValue(['mapping', 'lod_columns'], NULL) ?? ($data->reconcileconfig->columns ?? []);
+        $reconcile_column_settings = (array) $reconcile_column_settings;
+        //@ TODO we should remove from settings columns not present in the Source Data.
+        // Forms state will do that automatically but i prefer that as a sanity check
+        $form['mapping']['lod_columns'] = [
+          '#type' => 'select',
+          '#title' => $this->t('Select which columns you want to reconcile against LoD providers'),
+          '#default_value' => $reconcile_column_settings,
+          '#options' => array_combine($column_keys, $column_keys),
+          '#size' => count($column_keys),
+          '#multiple' => TRUE,
+          '#description' => $this->t('Columns that contain data you want to reconcile against LoD providers'),
+          '#empty_option' => $this->t('- Please select columns -'),
+          '#ajax' => [
+            'callback' => [$this, 'lodOptionsAjaxCallback'],
+            'wrapper' => 'lod-options-wrapper',
+            'event' => 'change',
+          ],
+        ];
+        $form['lod_options'] = [
+          '#type' => 'hidden',
+          '#prefix' => '<div id="lod-options-wrapper">',
+          '#suffix' => '</div>',
+        ];
+        $saved_reconcile_mapping_settings = [];
+        if ($data->reconcileconfig->mappings ?? NULL) {
+          foreach ($data->reconcileconfig->mappings as $column => $mapping) {
+            $saved_reconcile_mapping_settings[md5($column)] = $mapping;
           }
         }
+
+        $reconcile_mapping_settings = $form_state->getValue(['lod_options', 'mappings'], NULL) ?? ($saved_reconcile_mapping_settings ?? NULL);
+        $reconcile_mapping_settings = (array) $reconcile_mapping_settings;
+
+        if ($reconcile_column_settings) {
+          $source_options = $reconcile_column_settings;
+          // We convert the values into its md5 representation, then flip
+          // This is because the webform_mapping element uses a value callback
+          // that converts form state values from Drupal Nested Arrays, which
+          // Parses ][  anything that looks like that, breaking e.g XML to CSV
+          // column headers with Xpaths.
+
+          foreach ($source_options as $key => &$value) {
+            $value = md5($value);
+          }
+          $source_options = array_flip($source_options);
+          $column_options = $this->AmiLoDService::AMI_FORM_EXPOSED_LOD_SOURCES;
+          // Fetch also Custom ones. The format will be "custom;the_custom_lod_entity_id"
+          $column_options = $column_options + $this->AmiLoDService->getCustomLoDEndpoints();
+          $form['lod_options']['#type'] = 'fieldset';
+          $form['lod_options']['#tree'] = TRUE;
+
+          $form['lod_options']['mappings'] = [
+            '#type' => 'webform_mapping',
+            '#title' => $this->t('LoD Sources'),
+            '#description' => $this->t(
+              'Please select how your chosen Columns will be LoD reconciled'
+            ),
+            '#description_display' => 'before',
+            '#empty_option' => $this->t('- Let AMI decide -'),
+            '#empty_value' => NULL,
+            '#default_value' => $reconcile_mapping_settings,
+            '#required' => TRUE,
+            '#destination__multiple' => TRUE,
+            '#source' => $source_options,
+            '#source__title' => $this->t('LoD reconcile options'),
+            '#destination__title' => $this->t('LoD Authority Sources'),
+            '#destination' => $column_options,
+            '#destination__size' => count($column_options),
+          ];
+          $form['lod_options']['select_preview'] = [
+            '#type' => 'select',
+            '#title' => $this->t('Choose a Column to Preview'),
+            '#options' => array_combine($source_options, $source_options),
+            '#default_value' => $form_state->getValue(['lod_options','select_preview']),
+            '#description' => $this->t('We will attempt to fetch first cells holding a string of delimited values (by "|@|" or ";"). Additionally, if any selected column cell\'s holds a valid JSON, e.g. any simple lists of values (e.g ["pup","dog","canine"], and/or an object with any property where the JSON key name contains one of the following strings: "label, value, type, name". URL/URN or URI will be not taken in account.'),
+          ];
+          $form['lod_options']['preview'] = [
+            '#type' => 'button',
+            '#op' => 'preview',
+            '#value' => $this->t('Inspect cleaned/split up/or JSON decoded column values'),
+            '#ajax' => [
+              'callback' => [$this, 'ajaxColumPreview'],
+            ],
+          ];
+        }
+      }
+      else {
+        $form = [];
+        $form['status'] = [
+          '#tree' => TRUE,
+          '#type' => 'fieldset',
+          '#title' => $this->t(
+            'Error'
+          ),
+          '#markup' => $this->t(
+            'Sorry. This AMI set has no Source CSV attached and thus there is nothing to LoD reconciliate. Please edit this AMI set and add a CSV with your source data, having at least the same mapped columns present in your configuration and also proper UUIDs for each row (normally under a <em>node_uuid<em> column, if not manually overriden).'
+          ),
+        ];
+        return $form;
       }
 
       $notprocessnow = $form_state->getValue('not_process_now', NULL);

--- a/src/Plugin/Action/AmiStrawberryfieldCSVexport.php
+++ b/src/Plugin/Action/AmiStrawberryfieldCSVexport.php
@@ -372,7 +372,10 @@ class AmiStrawberryfieldCSVexport extends ConfigurableActionBase implements Depe
       if ($this->configuration['create_ami_set'] && $this->context['sandbox']['ado_type_exists']) {
         $ami_set = TRUE;
       }
-      $logger_channel = (string) $this->context['sandbox']['logger_channel'] ?? 'ami';
+      $logger_channel = 'ami';
+      if (isset($this->context['sandbox']['logger_channel']) && !empty($this->context['sandbox']['logger_channel'])) {
+        $logger_channel =  (string) $this->context['sandbox']['logger_channel'];
+      }
       $file_id = $this->AmiUtilityService->csv_save($data, 'node_uuid', TRUE, $ami_set, FALSE, $logger_channel);
       if ($file_id && $this->configuration['create_ami_set'] && $this->context['sandbox']['ado_type_exists']) {
         $amisetdata = new \stdClass();
@@ -408,15 +411,15 @@ class AmiStrawberryfieldCSVexport extends ConfigurableActionBase implements Depe
         if ($amiset_id) {
           $url = Url::fromRoute('entity.ami_set_entity.canonical',
             ['ami_set_entity' => $amiset_id]);
-          $message = $this->t('Well Done! New AMI Set was created and you can <a href="@url">see it here</a>',
-            ['@url' => $url->toString()]);
+          $message = $this->t('Well Done! New AMI Set was created and you can <a href=":url">see it here</a>',
+            [':url' => $url->toString()]);
           $this->messenger()
             ->addStatus($message);
         }
         return $message;
       }
       else if ($this->configuration['create_ami_set'] && !$this->context['sandbox']['ado_type_exists']) {
-        $message = $this->t('AMI Set could not be created because object(s) are missing the type key.');
+        $message = $this->t('AMI Set could not be created because object(s) are missing the "type" key.');
         $this->messenger()
              ->addStatus($message);
         return $message;
@@ -576,21 +579,6 @@ class AmiStrawberryfieldCSVexport extends ConfigurableActionBase implements Depe
     }
 
     return $this->context['sandbox']['cid_prefix'] . $this->context['sandbox']['current_batch'];
-  }
-
-  /**
-   * Prepares sandbox data (header and cache ID).
-   *
-   * @return array
-   *   Table header.
-   */
-  protected function getHeader() {
-    // Build output header array.
-    $header = &$this->context['sandbox']['header'];
-    if (!empty($header)) {
-      return $header;
-    }
-    return $this->setHeader();
   }
 
   public function getConfiguration() {

--- a/src/Plugin/Action/AmiStrawberryfieldCSVexport.php
+++ b/src/Plugin/Action/AmiStrawberryfieldCSVexport.php
@@ -419,7 +419,7 @@ class AmiStrawberryfieldCSVexport extends ConfigurableActionBase implements Depe
       else if ($this->configuration['create_ami_set'] && !$this->context['sandbox']['ado_type_exists']) {
         $message = $this->t('AMI Set could not be created because object(s) are missing the "type" key.');
         $this->messenger()
-             ->addStatus($message);
+             ->addWarning($message);
         return $message;
       }
     }

--- a/src/Plugin/Action/AmiStrawberryfieldCSVexport.php
+++ b/src/Plugin/Action/AmiStrawberryfieldCSVexport.php
@@ -373,7 +373,7 @@ class AmiStrawberryfieldCSVexport extends ConfigurableActionBase implements Depe
         $ami_set = TRUE;
       }
       $logger_channel = (string) $this->context['sandbox']['logger_channel'] ?? 'ami';
-      $file_id = $this->AmiUtilityService->csv_save($data, 'node_uuid', TRUE, $ami_set, $logger_channel);
+      $file_id = $this->AmiUtilityService->csv_save($data, 'node_uuid', TRUE, $ami_set, FALSE, $logger_channel);
       if ($file_id && $this->configuration['create_ami_set'] && $this->context['sandbox']['ado_type_exists']) {
         $amisetdata = new \stdClass();
         $amisetdata->plugin = 'spreadsheet';

--- a/src/Plugin/Action/AmiStrawberryfieldCSVexport.php
+++ b/src/Plugin/Action/AmiStrawberryfieldCSVexport.php
@@ -5,7 +5,6 @@ namespace Drupal\ami\Plugin\Action;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
 use Drupal\Core\Url;
-use Drupal\Core\Link;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Action\ConfigurableActionBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -24,7 +23,6 @@ use Drupal\views_bulk_operations\Action\ViewsBulkOperationsActionInterface;
 use Drupal\views_bulk_operations\Action\ViewsBulkOperationsPreconfigurationInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Provides an action that export SBFs to CSV.

--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -952,6 +952,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
          // Ignore status for updates if status_keep == TRUE.
          if ($status && is_string($status) && $status_keep == FALSE) {
            $node->set('moderation_state', $status);
+           $nodeValues['moderation_state'] = $status;
            $status = 0;
          }
          /** @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */

--- a/src/Plugin/QueueWorker/IngestADOQueueWorker.php
+++ b/src/Plugin/QueueWorker/IngestADOQueueWorker.php
@@ -293,7 +293,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
         'manyfiles' => Number of files (passed by \Drupal\ami\Form\amiSetEntityProcessForm::submitForm) that will trigger queue processing for files,
         'ops_skip_onmissing_file' => Skips ADO operations if a passed/mapped file is not present,
         'ops_forcemanaged_destination_file' => Forces Archipelago to manage a files destination when the source matches the destination Schema (e.g S3),
-        'time_submitted' => Timestamp on when the queue was sendt All Entries will share the same
+        'time_submitted' => Timestamp on when the queue was sent All Entries will share the same
       ];
     */
     /* Data info for a File has this structure
@@ -364,7 +364,7 @@ class IngestADOQueueWorker extends QueueWorkerBase implements ContainerFactoryPl
 
     // This will simply go to an alternate processing on this same Queue Worker
     // Just for files.
-    // No Try/catch for processFile invokation at this level,
+    // No Try/catch for processFile invocation at this level,
     // since it has its own wrapping try/catch logic.
     if (!empty($data->info['filename']) && !empty($data->info['file_column']) && !empty($data->info['processed_row'])) {
       $this->processFile($data);

--- a/src/Plugin/QueueWorker/LoDQueueWorker.php
+++ b/src/Plugin/QueueWorker/LoDQueueWorker.php
@@ -202,9 +202,9 @@ class LoDQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginIn
           }
         }
 
-        $newdata['data'][0][$lod_route_column_name] = json_encode($lod, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) ?? '';
+        $newdata['data'][0][$lod_route_column_name] = json_encode($lod, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE|JSON_HEX_QUOT) ?? '';
         $newdata['data'][0]['original'] = (string) $data->info['label'];
-        $newdata['data'][0]['csv_columns'] = json_encode((array)$data->info['csv_columns']) ?? '';
+        $newdata['data'][0]['csv_columns'] = json_encode((array)$data->info['csv_columns'], JSON_HEX_QUOT) ?? '';
         // Adds a "Checked" column used to mark manually reconciliated elements.
         $newdata['data'][0]['checked'] = FALSE;
         // Context data is simpler


### PR DESCRIPTION
# What?

See #267 and #263 

Working.

 Its a LOT of code and i need to improve the UI + Solve a the need of also simulating (for EAD/SYNC Ops) Children CSVs.

 That is an extra development that goes into the Metadata Template preview too.
This includes JS to disable any rendered links during the Preview, handling around the fact that a Simulated ADO has no `node->id()` (which breaks URL renderings, etc) , catches rendering errors, converts messages() into Ajax Commands and even allows an HTML Existing ADO with same UUID. + New ADO side by side diff.
It also handles Files not found (checks for local/zip and remote via HEAD) and reports both found/not found

Note: Because I am single handed-ly doing this, this pull also includes #264. That way I do not need to rebase once I merge (what ever I decide needs to be merged before)